### PR TITLE
fix typos

### DIFF
--- a/resources/views/docs/dropmenu.blade.php
+++ b/resources/views/docs/dropmenu.blade.php
@@ -128,7 +128,7 @@
     </pre>
     <h3>trigger_on</h3>
     <p>
-        By default the Dropomenu is displayed when you click on the trigger. It is possible to change this behaviour by defining the
+        By default the Dropmenu is displayed when you click on the trigger. It is possible to change this behaviour by defining the
         <code class="text-red-500 inline">trigger_on</code> attribute. There are only two available options: <code class="inline">click</code> and <code class="inline">mouseover</code>.
     </p>
     <div class="text-center">

--- a/resources/views/docs/emptystate.blade.php
+++ b/resources/views/docs/emptystate.blade.php
@@ -97,7 +97,7 @@
     </pre>
 
     <p>
-        You can also have empty states with no call to action buttons. For example, a "Recent Activities" section that fills up when users perform activities throughtout the app. An empty state for a case like that will necessarily need no action to be performed.
+        You can also have empty states with no call to action buttons. For example, a "Recent Activities" section that fills up when users perform activities throughout the app. An empty state for a case like that will necessarily need no action to be performed.
         To achieve this, you should leave out the <code class="inline text-red-500">button_label</code> attribute or set it to an empty string.
     </p>
 
@@ -115,8 +115,8 @@
 
                 &lt;x-bladewind::empty-state
                     image="/assets/images/no-activity.svg"
-                    message="Your recent activites list will take shape as
-                            &lt;br/&gt; soon as your organization has some activty"&gt;
+                    message="Your recent activities list will take shape as
+                            &lt;br/&gt; soon as your organization has some activity"&gt;
                 &lt;/x-bladewind::empty-state&gt;
 
             &lt;/x-bladewind.card&gt;

--- a/resources/views/docs/icon.blade.php
+++ b/resources/views/docs/icon.blade.php
@@ -122,7 +122,7 @@
     </p>
     <h3>SVG Image Files</h3>
     <p>
-        BladewindUI serves all the Hericons icons from <code class="inline">public > vendor > bladewind > icons > [solid, outline]</code>.
+        BladewindUI serves all the Heroicon icons from <code class="inline">public > vendor > bladewind > icons > [solid, outline]</code>.
         As stated earlier, the default icons served are outlines, so the <em>outline</em> directory is used. When you specify <code class="inline text-red-500">type="solid"</code>, the <em>solid</em> directory is used.
         You can place your own SVG files in either the outline or solid directories and then enter the file name (without .svg) in the name attribute of the component.
     </p>

--- a/resources/views/docs/input.blade.php
+++ b/resources/views/docs/input.blade.php
@@ -658,7 +658,7 @@
         <tr>
             <td>numeric</td>
             <td>false</td>
-            <td>Sepcifies if the input element should accept only numeric characters. <br /><code class="inline">true</code> <code class="inline">false</code></td>
+            <td>Specifies if the input element should accept only numeric characters. <br /><code class="inline">true</code> <code class="inline">false</code></td>
         </tr>
         <tr>
             <td>required</td>

--- a/resources/views/docs/select.blade.php
+++ b/resources/views/docs/select.blade.php
@@ -132,13 +132,13 @@
 <pre class="language-html line-numbers">
 <code>
 &lt;x-bladewind::select name="labels" required="true" :data="$countries"
-    label="WWhere are you from?"/&gt;
+    label="Where are you from?"/&gt;
 </code>
 </pre>
     <p><x-bladewind::select name="clear_labels" :data="$countries" data="{{ json_encode($countries) }}" clearable="true" label="Where are you from?" /></p>
 <pre class="language-html line-numbers">
 <code>
-&lt;x-bladewind::select name="clear_labels" label="WWhere are you from?"
+&lt;x-bladewind::select name="clear_labels" label="Where are you from?"
     :data="$countries" /&gt;
 </code>
 </pre>
@@ -491,7 +491,7 @@
 &lt;x-bladewind::empty-state
     name="no_users"
     for_select="true"
-    message="TThere are currently no users in your workspace. We need to fix that"
+    message="There are currently no users in your workspace. We need to fix that"
     button_label="Add User"
     image="/assets/images/user.png"
     onclick="showModal('new-user')"&gt;&lt;/x-bladewind::empty-state&gt;
@@ -779,7 +779,7 @@
         <tr>
             <td>selectByValue(value)</td>
             <td>Select one of the component values. The value you pass needs to exist in the Select's list of items else the command will simply be ignored.
-                This does not work for multiple values yet. You can use it on a mutiple select to select multiple values but you will need to call the method multiple times.
+                This does not work for multiple values yet. You can use it on a multiple select to select multiple values but you will need to call the method multiple times.
                 <br /><br />
                 <code class="inline">bw_country_multiple::selectByValue('gh');</code>
                 <code class="inline">bw_country_multiple::selectByValue('ng');</code>


### PR DESCRIPTION
While reading the docs of Bladewind I noticed some small typos and fixed them. I did not go through every page due to some time constraints but this should cover all the files in the pr.

Only html text was changed, no css classes nor element attributes were changed in this pr.

Hope this helps! 😄 