### PR TITLE
Add MCP server and machine-readable component documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ deploy.php
 dev-composer.json
 deploy.php
 /.claude
+NOTETOSELF.md

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ deploy.php
 /public/vendor
 dev-composer.json
 deploy.php
+/.claude

--- a/README.md
+++ b/README.md
@@ -103,6 +103,44 @@ Check out the full documentation on https://bladewindui.com.
 
 <br /><br />
 
+## MCP Documentation
+
+The `mcp/` directory contains clean, machine-readable Markdown documentation for every component. These files are intended for consumption by MCP (Model Context Protocol) servers so that AI assistants can understand how to use BladewindUI components.
+
+Each file includes frontmatter, prose descriptions, fenced `blade` code examples, and a full attribute reference table. An index of all components is at `mcp/index.md`.
+
+### Generating MCP docs for new components
+
+When you add a new component to the documentation site, run `generate-mcp.php` to produce its MCP entry automatically.
+
+**Requirements:** PHP 8+, an [Anthropic API key](https://console.anthropic.com/).
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**Generate a new entry:**
+
+```bash
+php generate-mcp.php <component-name>
+```
+
+**Preview without writing files:**
+
+```bash
+php generate-mcp.php <component-name> --dry-run
+```
+
+**Generate and add to `mcp/index.md`:**
+
+```bash
+php generate-mcp.php <component-name> --update-index
+```
+
+The script looks for `resources/views/docs/<component-name>.blade.php`. If the blade filename differs from the component slug (e.g. `empty-state` → `emptystate.blade.php`), add an entry to the `$FILENAME_OVERRIDES` map near the top of `generate-mcp.php`.
+
+<br /><br />
+
 ## Questions and General Info
 
 If you want to ask anything at all or report a security vulnerability, please e-mail [mike@bladewindui.com](mailto:mike@bladewindui.com) or tweet [@bladewindui](https://twitter.com/bladewindui)

--- a/app/Http/Controllers/McpController.php
+++ b/app/Http/Controllers/McpController.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Response;
 /**
  * Remote MCP (Model Context Protocol) server for BladewindUI documentation.
  *
- * Implements the MCP Streamable HTTP transport (spec 2025-03-26).
+ * Implements the MCP Streamable HTTP transport (spec 2025-11-25).
  * Endpoint: POST /mcp/server
  *
  * Capabilities exposed:
@@ -18,10 +18,10 @@ use Illuminate\Http\Response;
  */
 class McpController extends Controller
 {
-    private const PROTOCOL_VERSION = '2025-03-26';
-    private const SERVER_NAME      = 'bladewindui-docs';
-    private const SERVER_VERSION   = '1.0.0';
-    private const URI_SCHEME       = 'bladewindui://docs/';
+    private const string PROTOCOL_VERSION = '2025-11-25';
+    private const string SERVER_NAME      = 'bladewindui-docs';
+    private const string SERVER_VERSION   = '1.0.0';
+    private const string URI_SCHEME       = 'bladewindui://docs/';
 
     private string $mcpDir;
 

--- a/app/Http/Controllers/McpController.php
+++ b/app/Http/Controllers/McpController.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * Remote MCP (Model Context Protocol) server for BladewindUI documentation.
+ *
+ * Implements the MCP Streamable HTTP transport (spec 2025-03-26).
+ * Endpoint: POST /mcp/server
+ *
+ * Capabilities exposed:
+ *   resources — one resource per mcp/*.md file (readable by URI)
+ *   tools     — list_components, get_component_docs, search_components
+ */
+class McpController extends Controller
+{
+    private const PROTOCOL_VERSION = '2025-03-26';
+    private const SERVER_NAME      = 'bladewindui-docs';
+    private const SERVER_VERSION   = '1.0.0';
+    private const URI_SCHEME       = 'bladewindui://docs/';
+
+    private string $mcpDir;
+
+    public function __construct()
+    {
+        $this->mcpDir = base_path('mcp');
+    }
+
+    // ── Entry point ───────────────────────────────────────────────────────────
+
+    public function handle(Request $request): JsonResponse|Response
+    {
+        $body = $request->json()->all();
+
+        // Batch request (array of messages)
+        if (array_is_list($body) && count($body) > 0 && is_array($body[0])) {
+            $responses = array_values(
+                array_filter(array_map([$this, 'dispatch'], $body))
+            );
+            return response()->json($responses);
+        }
+
+        // Single request
+        $result = $this->dispatch($body);
+
+        // Notifications have no id and require no response body
+        if ($result === null) {
+            return response()->noContent();
+        }
+
+        return response()->json($result);
+    }
+
+    // ── Dispatcher ────────────────────────────────────────────────────────────
+
+    private function dispatch(array $message): ?array
+    {
+        $id     = $message['id']     ?? null;
+        $method = $message['method'] ?? '';
+        $params = $message['params'] ?? [];
+
+        // JSON-RPC notifications (no id) must not receive a response
+        if ($id === null && !str_starts_with($method, 'initialize')) {
+            return null;
+        }
+
+        return match ($method) {
+            'initialize'              => $this->initialize($id, $params),
+            'notifications/initialized' => null,
+            'ping'                    => $this->pong($id),
+            'resources/list'          => $this->resourcesList($id, $params),
+            'resources/read'          => $this->resourcesRead($id, $params),
+            'tools/list'              => $this->toolsList($id),
+            'tools/call'              => $this->toolsCall($id, $params),
+            default                   => $this->methodNotFound($id, $method),
+        };
+    }
+
+    // ── MCP methods ───────────────────────────────────────────────────────────
+
+    private function initialize(mixed $id, array $params): array
+    {
+        return $this->result($id, [
+            'protocolVersion' => self::PROTOCOL_VERSION,
+            'capabilities'    => [
+                'resources' => ['subscribe' => false, 'listChanged' => false],
+                'tools'     => new \stdClass(),
+            ],
+            'serverInfo' => [
+                'name'    => self::SERVER_NAME,
+                'version' => self::SERVER_VERSION,
+            ],
+            'instructions' => implode(' ', [
+                'This MCP server exposes the BladewindUI component library documentation.',
+                'Use resources/list to discover all available components.',
+                'Use resources/read with a bladewindui://docs/{component} URI to read a component\'s full docs.',
+                'Use the search_components tool to find components by keyword.',
+            ]),
+        ]);
+    }
+
+    private function pong(mixed $id): array
+    {
+        return $this->result($id, new \stdClass());
+    }
+
+    private function resourcesList(mixed $id, array $params): array
+    {
+        $files = $this->getMarkdownFiles();
+        $resources = [];
+
+        // Index first
+        if (isset($files['index'])) {
+            $resources[] = [
+                'uri'         => self::URI_SCHEME . 'index',
+                'name'        => 'BladewindUI Component Index',
+                'description' => 'Index of all BladewindUI components with their tags and doc links.',
+                'mimeType'    => 'text/markdown',
+            ];
+        }
+
+        // One resource per component file
+        foreach ($files as $slug => $path) {
+            if ($slug === 'index') continue;
+
+            $title = $this->extractTitle($path) ?? $this->slugToTitle($slug);
+
+            $resources[] = [
+                'uri'         => self::URI_SCHEME . $slug,
+                'name'        => $title,
+                'description' => "BladewindUI {$title} documentation — usage, examples, and attribute reference.",
+                'mimeType'    => 'text/markdown',
+            ];
+        }
+
+        return $this->result($id, ['resources' => $resources]);
+    }
+
+    private function resourcesRead(mixed $id, array $params): array
+    {
+        $uri  = $params['uri'] ?? '';
+        $slug = str_replace(self::URI_SCHEME, '', $uri);
+
+        if (!$slug || !preg_match('/^[\w-]+$/', $slug)) {
+            return $this->error($id, -32602, "Invalid resource URI: {$uri}");
+        }
+
+        $path = "{$this->mcpDir}/{$slug}.md";
+
+        if (!file_exists($path)) {
+            return $this->error($id, -32002, "Resource not found: {$uri}");
+        }
+
+        return $this->result($id, [
+            'contents' => [[
+                'uri'      => $uri,
+                'mimeType' => 'text/markdown',
+                'text'     => file_get_contents($path),
+            ]],
+        ]);
+    }
+
+    private function toolsList(mixed $id): array
+    {
+        return $this->result($id, [
+            'tools' => [
+                [
+                    'name'        => 'list_components',
+                    'description' => 'List all available BladewindUI components with their Blade tag and doc URI.',
+                    'inputSchema' => [
+                        'type'       => 'object',
+                        'properties' => new \stdClass(),
+                        'required'   => [],
+                    ],
+                ],
+                [
+                    'name'        => 'get_component_docs',
+                    'description' => 'Get the full documentation for a specific BladewindUI component by name.',
+                    'inputSchema' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'name' => [
+                                'type'        => 'string',
+                                'description' => 'Component slug, e.g. "button", "table", "horizontal-line-graph".',
+                            ],
+                        ],
+                        'required' => ['name'],
+                    ],
+                ],
+                [
+                    'name'        => 'search_components',
+                    'description' => 'Search BladewindUI component docs by keyword. Returns matching component names and relevant excerpts.',
+                    'inputSchema' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'query' => [
+                                'type'        => 'string',
+                                'description' => 'Keyword or phrase to search for, e.g. "pagination", "color", "slot".',
+                            ],
+                        ],
+                        'required' => ['query'],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function toolsCall(mixed $id, array $params): array
+    {
+        $name      = $params['name']      ?? '';
+        $arguments = $params['arguments'] ?? [];
+
+        return match ($name) {
+            'list_components'    => $this->toolListComponents($id),
+            'get_component_docs' => $this->toolGetComponentDocs($id, $arguments),
+            'search_components'  => $this->toolSearchComponents($id, $arguments),
+            default              => $this->error($id, -32601, "Unknown tool: {$name}"),
+        };
+    }
+
+    // ── Tool implementations ──────────────────────────────────────────────────
+
+    private function toolListComponents(mixed $id): array
+    {
+        $files  = $this->getMarkdownFiles();
+        $output = [];
+
+        foreach ($files as $slug => $path) {
+            if ($slug === 'index') continue;
+
+            $title     = $this->extractTitle($path) ?? $this->slugToTitle($slug);
+            $component = $this->extractFrontmatter($path, 'component') ?? "x-bladewind::{$slug}";
+
+            $output[] = "- **{$title}** — `{$component}` — `bladewindui://docs/{$slug}`";
+        }
+
+        sort($output);
+
+        return $this->toolResult($id, implode("\n", $output));
+    }
+
+    private function toolGetComponentDocs(mixed $id, array $args): array
+    {
+        $name = trim(strtolower($args['name'] ?? ''));
+
+        if (!$name) {
+            return $this->toolError($id, 'The `name` argument is required.');
+        }
+
+        $path = "{$this->mcpDir}/{$name}.md";
+
+        if (!file_exists($path)) {
+            // Fuzzy fallback: try matching by partial slug
+            $files = $this->getMarkdownFiles();
+            foreach (array_keys($files) as $slug) {
+                if (str_contains($slug, $name) || str_contains($name, $slug)) {
+                    $path = $files[$slug];
+                    break;
+                }
+            }
+        }
+
+        if (!file_exists($path)) {
+            return $this->toolError($id, "No documentation found for component \"{$name}\". Use list_components to see available components.");
+        }
+
+        return $this->toolResult($id, file_get_contents($path));
+    }
+
+    private function toolSearchComponents(mixed $id, array $args): array
+    {
+        $query = trim($args['query'] ?? '');
+
+        if (!$query) {
+            return $this->toolError($id, 'The `query` argument is required.');
+        }
+
+        $files   = $this->getMarkdownFiles();
+        $matches = [];
+
+        foreach ($files as $slug => $path) {
+            if ($slug === 'index') continue;
+
+            $content = file_get_contents($path);
+
+            if (!stripos($content, $query) && !stripos($slug, $query)) {
+                continue;
+            }
+
+            $title = $this->extractTitle($path) ?? $this->slugToTitle($slug);
+
+            // Extract up to 3 context lines around each match
+            $excerpts = $this->extractExcerpts($content, $query, 3);
+
+            $matches[] = "### {$title} (`bladewindui://docs/{$slug}`)\n\n" . implode("\n\n---\n\n", $excerpts);
+        }
+
+        if (empty($matches)) {
+            return $this->toolResult($id, "No components found matching \"{$query}\".");
+        }
+
+        $count  = count($matches);
+        $header = "Found {$count} component" . ($count !== 1 ? 's' : '') . " matching \"{$query}\":\n\n";
+
+        return $this->toolResult($id, $header . implode("\n\n---\n\n", $matches));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** @return array<string, string>  slug => absolute path */
+    private function getMarkdownFiles(): array
+    {
+        $files = [];
+
+        foreach (glob("{$this->mcpDir}/*.md") as $path) {
+            $slug         = basename($path, '.md');
+            $files[$slug] = $path;
+        }
+
+        ksort($files);
+
+        return $files;
+    }
+
+    private function extractFrontmatter(string $path, string $key): ?string
+    {
+        $content = file_get_contents($path);
+        if (preg_match('/^' . preg_quote($key, '/') . ':\s*(.+)$/m', $content, $m)) {
+            return trim($m[1]);
+        }
+        return null;
+    }
+
+    private function extractTitle(string $path): ?string
+    {
+        return $this->extractFrontmatter($path, 'title');
+    }
+
+    private function slugToTitle(string $slug): string
+    {
+        return ucwords(str_replace('-', ' ', $slug));
+    }
+
+    /** Return up to $max excerpts (3 lines of context) around each occurrence of $query in $content. */
+    private function extractExcerpts(string $content, string $query, int $max): array
+    {
+        $lines    = explode("\n", $content);
+        $excerpts = [];
+        $found    = [];
+
+        foreach ($lines as $i => $line) {
+            if (count($excerpts) >= $max) break;
+
+            if (!stripos($line . ' ', $query)) continue;
+
+            // Avoid overlapping excerpts
+            foreach ($found as $prev) {
+                if (abs($i - $prev) < 4) continue 2;
+            }
+
+            $found[]    = $i;
+            $start      = max(0, $i - 1);
+            $end        = min(count($lines) - 1, $i + 1);
+            $excerpts[] = '> ' . implode("\n> ", array_slice($lines, $start, $end - $start + 1));
+        }
+
+        return $excerpts ?: ['*(no excerpt available)*'];
+    }
+
+    // ── JSON-RPC response builders ────────────────────────────────────────────
+
+    private function result(mixed $id, mixed $result): array
+    {
+        return ['jsonrpc' => '2.0', 'id' => $id, 'result' => $result];
+    }
+
+    private function error(mixed $id, int $code, string $message): array
+    {
+        return ['jsonrpc' => '2.0', 'id' => $id, 'error' => ['code' => $code, 'message' => $message]];
+    }
+
+    private function methodNotFound(mixed $id, string $method): array
+    {
+        return $this->error($id, -32601, "Method not found: {$method}");
+    }
+
+    private function toolResult(mixed $id, string $text): array
+    {
+        return $this->result($id, [
+            'content' => [['type' => 'text', 'text' => $text]],
+            'isError'  => false,
+        ]);
+    }
+
+    private function toolError(mixed $id, string $message): array
+    {
+        return $this->result($id, [
+            'content' => [['type' => 'text', 'text' => $message]],
+            'isError'  => true,
+        ]);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,8 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        // Exclude the MCP server endpoint from CSRF — it is consumed by external AI tools
+        $middleware->validateCsrfTokens(except: ['mcp/server']);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
     "$schema": "https://getcomposer.org/schema.json",
     "name": "mkocansey/bladewind-docs",
     "type": "project",
-    "description": "The skeleton application for the Laravel framework.",
+    "description": "BladewindUI Documentation",
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
         "php": "^8.4",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.9",
-        "mkocansey/bladewind": "dev-development"
+        "mkocansey/bladewind": "^4.1"
     },
     "require-dev": {
         "deployer/deployer": "^7.5",
@@ -71,9 +71,5 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "repositories": {
-        "mkocansey/bladewind": {
-            "type": "path",
-            "url": "/Users/mkocansey/projects/kursor/bladewindui"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^8.4",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.9",
-        "mkocansey/bladewind": "^4.1"
+        "mkocansey/bladewind": "~4.1"
     },
     "require-dev": {
         "deployer/deployer": "^7.5",
@@ -70,6 +70,5 @@
     },
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "repositories": {
-    }
+    "repositories": {}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b094c18988028c38793e1607f4ad684",
+    "content-hash": "a7019e11ec0745426c1890818a486ad1",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.14.0",
+            "version": "0.14.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2"
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
-                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
+                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.0"
+                "source": "https://github.com/brick/math/tree/0.14.8"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-29T12:40:03+00:00"
+            "time": "2026-02-10T14:33:43+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -379,29 +379,28 @@
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "v3.4.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "8c784d071debd117328803d86b2097615b457500"
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/8c784d071debd117328803d86b2097615b457500",
-                "reference": "8c784d071debd117328803d86b2097615b457500",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/d61a8a9604ec1f8c3d150d09db6ce98b32675013",
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0",
-                "webmozart/assert": "^1.0"
+                "php": "^8.2|^8.3|^8.4|^8.5"
             },
             "replace": {
                 "mtdowling/cron-expression": "^1.0"
             },
             "require-dev": {
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0",
-                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.32|^2.1.31",
+                "phpunit/phpunit": "^8.5.48|^9.0"
             },
             "type": "library",
             "extra": {
@@ -432,7 +431,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dragonmantank/cron-expression/issues",
-                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.4.0"
+                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -440,7 +439,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T13:47:03+00:00"
+            "time": "2025-10-31T18:51:33+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -511,31 +510,31 @@
         },
         {
             "name": "fruitcake/php-cors",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruitcake/php-cors.git",
-                "reference": "3d158f36e7875e2f040f37bc0573956240a5a38b"
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/3d158f36e7875e2f040f37bc0573956240a5a38b",
-                "reference": "3d158f36e7875e2f040f37bc0573956240a5a38b",
+                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4|^8.0",
-                "symfony/http-foundation": "^4.4|^5.4|^6|^7"
+                "php": "^8.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan": "^2",
                 "phpunit/phpunit": "^9",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -566,7 +565,7 @@
             ],
             "support": {
                 "issues": "https://github.com/fruitcake/php-cors/issues",
-                "source": "https://github.com/fruitcake/php-cors/tree/v1.3.0"
+                "source": "https://github.com/fruitcake/php-cors/tree/v1.4.0"
             },
             "funding": [
                 {
@@ -578,28 +577,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-12T05:21:21+00:00"
+            "time": "2025-12-03T09:33:47+00:00"
         },
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.1.3",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3"
+                "phpoption/phpoption": "^1.9.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
             },
             "type": "library",
             "autoload": {
@@ -628,7 +627,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
             },
             "funding": [
                 {
@@ -640,29 +639,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:45:45+00:00"
+            "time": "2025-12-27T19:43:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -671,8 +671,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -750,7 +751,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
             },
             "funding": [
                 {
@@ -766,28 +767,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-07T22:54:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -833,7 +835,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -849,27 +851,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -877,8 +881,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -949,7 +954,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -965,20 +970,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
                 "shasum": ""
             },
             "require": {
@@ -987,7 +992,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1035,7 +1040,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
             },
             "funding": [
                 {
@@ -1051,20 +1056,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-05-23T22:00:21+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v12.31.1",
+            "version": "v12.61.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "281b711710c245dd8275d73132e92635be3094df"
+                "reference": "e8472ca9774452fe50841d9bdced060679f4d58d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/281b711710c245dd8275d73132e92635be3094df",
-                "reference": "281b711710c245dd8275d73132e92635be3094df",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e8472ca9774452fe50841d9bdced060679f4d58d",
+                "reference": "e8472ca9774452fe50841d9bdced060679f4d58d",
                 "shasum": ""
             },
             "require": {
@@ -1085,14 +1090,13 @@
                 "guzzlehttp/uri-template": "^1.0",
                 "laravel/prompts": "^0.3.0",
                 "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
                 "monolog/monolog": "^3.0",
                 "nesbot/carbon": "^3.8.4",
                 "nunomaduro/termwind": "^2.0",
-                "phiki/phiki": "^2.0.0",
                 "php": "^8.2",
                 "psr/container": "^1.1.1|^2.0.1",
                 "psr/log": "^1.0|^2.0|^3.0",
@@ -1106,8 +1110,8 @@
                 "symfony/mailer": "^7.2.0",
                 "symfony/mime": "^7.2.0",
                 "symfony/polyfill-php83": "^1.33",
-                "symfony/polyfill-php84": "^1.33",
-                "symfony/polyfill-php85": "^1.33",
+                "symfony/polyfill-php84": "^1.34",
+                "symfony/polyfill-php85": "^1.34",
                 "symfony/process": "^7.2.0",
                 "symfony/routing": "^7.2.0",
                 "symfony/uid": "^7.2.0",
@@ -1153,6 +1157,7 @@
                 "illuminate/process": "self.version",
                 "illuminate/queue": "self.version",
                 "illuminate/redis": "self.version",
+                "illuminate/reflection": "self.version",
                 "illuminate/routing": "self.version",
                 "illuminate/session": "self.version",
                 "illuminate/support": "self.version",
@@ -1177,13 +1182,13 @@
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
                 "opis/json-schema": "^2.4.1",
-                "orchestra/testbench-core": "^10.6.5",
+                "orchestra/testbench-core": "^10.9.0",
                 "pda/pheanstalk": "^5.0.6|^7.0.0",
                 "php-http/discovery": "^1.15",
-                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan": "^2.1.41",
                 "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
                 "predis/predis": "^2.3|^3.0",
-                "resend/resend-php": "^0.10.0",
+                "resend/resend-php": "^0.10.0|^1.0",
                 "symfony/cache": "^7.2.0",
                 "symfony/http-client": "^7.2.0",
                 "symfony/psr-http-message-bridge": "^7.2.0",
@@ -1217,7 +1222,7 @@
                 "predis/predis": "Required to use the predis connector (^2.3|^3.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
-                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
+                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0|^1.0).",
                 "symfony/cache": "Required to PSR-6 cache bridge (^7.2).",
                 "symfony/filesystem": "Required to enable support for relative symbolic links (^7.2).",
                 "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.2).",
@@ -1239,6 +1244,7 @@
                     "src/Illuminate/Filesystem/functions.php",
                     "src/Illuminate/Foundation/helpers.php",
                     "src/Illuminate/Log/functions.php",
+                    "src/Illuminate/Reflection/helpers.php",
                     "src/Illuminate/Support/functions.php",
                     "src/Illuminate/Support/helpers.php"
                 ],
@@ -1247,7 +1253,8 @@
                     "Illuminate\\Support\\": [
                         "src/Illuminate/Macroable/",
                         "src/Illuminate/Collections/",
-                        "src/Illuminate/Conditionable/"
+                        "src/Illuminate/Conditionable/",
+                        "src/Illuminate/Reflection/"
                     ]
                 }
             },
@@ -1271,36 +1278,36 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-23T15:33:04+00:00"
+            "time": "2026-06-04T14:22:52+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.7",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "a1891d362714bc40c8d23b0b1d7090f022ea27cc"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/a1891d362714bc40c8d23b0b1d7090f022ea27cc",
-                "reference": "a1891d362714bc40c8d23b0b1d7090f022ea27cc",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "ext-mbstring": "*",
                 "php": "^8.1",
-                "symfony/console": "^6.2|^7.0"
+                "symfony/console": "^6.2|^7.0|^8.0"
             },
             "conflict": {
                 "illuminate/console": ">=10.17.0 <10.25.0",
                 "laravel/framework": ">=10.17.0 <10.25.0"
             },
             "require-dev": {
-                "illuminate/collections": "^10.0|^11.0|^12.0",
+                "illuminate/collections": "^10.0|^11.0|^12.0|^13.0",
                 "mockery/mockery": "^1.5",
-                "pestphp/pest": "^2.3|^3.4",
+                "pestphp/pest": "^2.3|^3.4|^4.0",
                 "phpstan/phpstan": "^1.12.28",
                 "phpstan/phpstan-mockery": "^1.1.3"
             },
@@ -1328,33 +1335,33 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.7"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2025-09-19T13:47:56+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.5",
+            "version": "v2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "3832547db6e0e2f8bb03d4093857b378c66eceed"
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/3832547db6e0e2f8bb03d4093857b378c66eceed",
-                "reference": "3832547db6e0e2f8bb03d4093857b378c66eceed",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.1"
             },
             "require-dev": {
-                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "nesbot/carbon": "^2.67|^3.0",
-                "pestphp/pest": "^2.36|^3.0",
+                "pestphp/pest": "^2.36|^3.0|^4.0",
                 "phpstan/phpstan": "^2.0",
-                "symfony/var-dumper": "^6.2.0|^7.0.0"
+                "symfony/var-dumper": "^6.2.0|^7.0.0|^8.0.0"
             },
             "type": "library",
             "extra": {
@@ -1391,20 +1398,20 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2025-09-22T17:29:40+00:00"
+            "time": "2026-04-16T14:03:50+00:00"
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.10.1",
+            "version": "v2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "22177cc71807d38f2810c6204d8f7183d88a57d3"
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/22177cc71807d38f2810c6204d8f7183d88a57d3",
-                "reference": "22177cc71807d38f2810c6204d8f7183d88a57d3",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/c9f80cc835649b5c1842898fb043f8cc098dd741",
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741",
                 "shasum": ""
             },
             "require": {
@@ -1413,7 +1420,7 @@
                 "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
                 "php": "^7.2.5|^8.0",
                 "psy/psysh": "^0.11.1|^0.12.0",
-                "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0"
+                "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.3|^1.4.2",
@@ -1455,22 +1462,22 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/v2.10.1"
+                "source": "https://github.com/laravel/tinker/tree/v2.11.1"
             },
-            "time": "2025-01-27T14:24:01+00:00"
+            "time": "2026-02-06T14:12:35+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "2.7.1",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/10732241927d3971d28e7ea7b5712721fa2296ca",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -1495,9 +1502,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -1507,7 +1514,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.8-dev"
+                    "dev-main": "2.9-dev"
                 }
             },
             "autoload": {
@@ -1564,7 +1571,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-20T12:47:49+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",
@@ -1650,16 +1657,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.30.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2203e3151755d874bb2943649dae1eb8533ac93e",
-                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -1727,22 +1734,22 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.30.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2025-06-25T13:29:59+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.30.0",
+            "version": "3.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
-                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10"
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/6691915f77c7fb69adfb87dcd550052dc184ee10",
-                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079",
                 "shasum": ""
             },
             "require": {
@@ -1776,9 +1783,9 @@
                 "local"
             ],
             "support": {
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.30.0"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
             },
-            "time": "2025-05-21T10:34:19+00:00"
+            "time": "2026-01-23T15:30:45+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -1838,33 +1845,38 @@
         },
         {
             "name": "league/uri",
-            "version": "7.5.1",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.5",
-                "php": "^8.1"
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "suggest": {
                 "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
                 "ext-fileinfo": "to create Data URI from file contennts",
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
-                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
-                "league/uri-components": "Needed to easily manipulate URI objects components",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1892,6 +1904,7 @@
             "description": "URI manipulation library",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
+                "URN",
                 "data-uri",
                 "file-uri",
                 "ftp",
@@ -1904,9 +1917,11 @@
                 "psr-7",
                 "query-string",
                 "querystring",
+                "rfc2141",
                 "rfc3986",
                 "rfc3987",
                 "rfc6570",
+                "rfc8141",
                 "uri",
                 "uri-template",
                 "url",
@@ -1916,7 +1931,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1924,26 +1939,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:40:02+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.5.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": "^8.1",
-                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
             "suggest": {
@@ -1951,6 +1965,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1975,7 +1990,7 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
                 "data-uri",
@@ -2000,7 +2015,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -2008,38 +2023,171 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:18:47+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "mkocansey/bladewind",
-            "version": "dev-v3-0-x",
+            "version": "v4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mkocansey/bladewind.git",
+                "reference": "bcfca0a373cdc2a25ff95aa8255867a94c5bcd98"
+            },
             "dist": {
-                "type": "path",
-                "url": "/Users/mkocansey/projects/kursor/bladewindui",
-                "reference": "03a25979213b337da856a779194155288d9026e9"
+                "type": "zip",
+                "url": "https://api.github.com/repos/mkocansey/bladewind/zipball/bcfca0a373cdc2a25ff95aa8255867a94c5bcd98",
+                "reference": "bcfca0a373cdc2a25ff95aa8255867a94c5bcd98",
+                "shasum": ""
             },
             "require": {
-                "php": ">=8.0"
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": ">=8.1"
+            },
+            "replace": {
+                "mkocansey/bladewind-accordion": "4.0.0",
+                "mkocansey/bladewind-alert": "4.0.0",
+                "mkocansey/bladewind-avatar": "4.0.0",
+                "mkocansey/bladewind-button": "4.0.0",
+                "mkocansey/bladewind-card": "4.0.0",
+                "mkocansey/bladewind-centered-content": "4.0.0",
+                "mkocansey/bladewind-chart": "4.0.0",
+                "mkocansey/bladewind-checkbox": "4.0.0",
+                "mkocansey/bladewind-checkcards": "4.0.0",
+                "mkocansey/bladewind-code": "4.0.0",
+                "mkocansey/bladewind-colorpicker": "4.0.0",
+                "mkocansey/bladewind-contact-card": "4.0.0",
+                "mkocansey/bladewind-content": "4.0.0",
+                "mkocansey/bladewind-core": "4.0.0",
+                "mkocansey/bladewind-datepicker": "4.0.0",
+                "mkocansey/bladewind-dropmenu": "4.0.0",
+                "mkocansey/bladewind-empty-state": "4.0.0",
+                "mkocansey/bladewind-filepicker": "4.0.0",
+                "mkocansey/bladewind-forms": "4.0.0",
+                "mkocansey/bladewind-horizontal-line-graph": "4.0.0",
+                "mkocansey/bladewind-icon": "4.0.0",
+                "mkocansey/bladewind-input": "4.0.0",
+                "mkocansey/bladewind-listview": "4.0.0",
+                "mkocansey/bladewind-modal": "4.0.0",
+                "mkocansey/bladewind-navigation": "4.0.0",
+                "mkocansey/bladewind-number": "4.0.0",
+                "mkocansey/bladewind-pagination": "4.0.0",
+                "mkocansey/bladewind-progress": "4.0.0",
+                "mkocansey/bladewind-radio": "4.0.0",
+                "mkocansey/bladewind-rating": "4.0.0",
+                "mkocansey/bladewind-script": "4.0.0",
+                "mkocansey/bladewind-select": "4.0.0",
+                "mkocansey/bladewind-slider": "4.0.0",
+                "mkocansey/bladewind-spinner": "4.0.0",
+                "mkocansey/bladewind-statistic": "4.0.0",
+                "mkocansey/bladewind-tab": "4.0.0",
+                "mkocansey/bladewind-table": "4.0.0",
+                "mkocansey/bladewind-tag": "4.0.0",
+                "mkocansey/bladewind-textarea": "4.0.0",
+                "mkocansey/bladewind-theme-switcher": "4.0.0",
+                "mkocansey/bladewind-timeline": "4.0.0",
+                "mkocansey/bladewind-timepicker": "4.0.0",
+                "mkocansey/bladewind-toggle": "4.0.0"
+            },
+            "require-dev": {
+                "symplify/monorepo-builder": "^11.0"
             },
             "type": "library",
             "extra": {
                 "laravel": {
                     "providers": [
+                        "Mkocansey\\Bladewind\\Core\\BladewindCoreServiceProvider",
+                        "Mkocansey\\Bladewind\\Icon\\BladewindIconServiceProvider",
+                        "Mkocansey\\Bladewind\\Script\\BladewindScriptServiceProvider",
+                        "Mkocansey\\Bladewind\\Spinner\\BladewindSpinnerServiceProvider",
+                        "Mkocansey\\Bladewind\\Button\\BladewindButtonServiceProvider",
+                        "Mkocansey\\Bladewind\\Alert\\BladewindAlertServiceProvider",
+                        "Mkocansey\\Bladewind\\Modal\\BladewindModalServiceProvider",
+                        "Mkocansey\\Bladewind\\Table\\BladewindTableServiceProvider",
+                        "Mkocansey\\Bladewind\\Input\\BladewindInputServiceProvider",
+                        "Mkocansey\\Bladewind\\Textarea\\BladewindTextareaServiceProvider",
+                        "Mkocansey\\Bladewind\\Select\\BladewindSelectServiceProvider",
+                        "Mkocansey\\Bladewind\\Checkbox\\BladewindCheckboxServiceProvider",
+                        "Mkocansey\\Bladewind\\Radio\\BladewindRadioServiceProvider",
+                        "Mkocansey\\Bladewind\\Toggle\\BladewindToggleServiceProvider",
+                        "Mkocansey\\Bladewind\\Datepicker\\BladewindDatepickerServiceProvider",
+                        "Mkocansey\\Bladewind\\Timepicker\\BladewindTimepickerServiceProvider",
+                        "Mkocansey\\Bladewind\\Colorpicker\\BladewindColorpickerServiceProvider",
+                        "Mkocansey\\Bladewind\\Filepicker\\BladewindFilepickerServiceProvider",
+                        "Mkocansey\\Bladewind\\Slider\\BladewindSliderServiceProvider",
+                        "Mkocansey\\Bladewind\\Checkcards\\BladewindCheckcardsServiceProvider",
+                        "Mkocansey\\Bladewind\\Number\\BladewindNumberServiceProvider",
+                        "Mkocansey\\Bladewind\\Code\\BladewindCodeServiceProvider",
+                        "Mkocansey\\Bladewind\\Card\\BladewindCardServiceProvider",
+                        "Mkocansey\\Bladewind\\ContactCard\\BladewindContactCardServiceProvider",
+                        "Mkocansey\\Bladewind\\Avatar\\BladewindAvatarServiceProvider",
+                        "Mkocansey\\Bladewind\\Accordion\\BladewindAccordionServiceProvider",
+                        "Mkocansey\\Bladewind\\Tag\\BladewindTagServiceProvider",
+                        "Mkocansey\\Bladewind\\Timeline\\BladewindTimelineServiceProvider",
+                        "Mkocansey\\Bladewind\\Statistic\\BladewindStatisticServiceProvider",
+                        "Mkocansey\\Bladewind\\Rating\\BladewindRatingServiceProvider",
+                        "Mkocansey\\Bladewind\\HorizontalLineGraph\\BladewindHorizontalLineGraphServiceProvider",
+                        "Mkocansey\\Bladewind\\EmptyState\\BladewindEmptyStateServiceProvider",
+                        "Mkocansey\\Bladewind\\CenteredContent\\BladewindCenteredContentServiceProvider",
+                        "Mkocansey\\Bladewind\\Chart\\BladewindChartServiceProvider",
+                        "Mkocansey\\Bladewind\\Progress\\BladewindProgressServiceProvider",
+                        "Mkocansey\\Bladewind\\Listview\\BladewindListviewServiceProvider",
+                        "Mkocansey\\Bladewind\\Tab\\BladewindTabServiceProvider",
+                        "Mkocansey\\Bladewind\\Dropmenu\\BladewindDropmenuServiceProvider",
+                        "Mkocansey\\Bladewind\\Pagination\\BladewindPaginationServiceProvider",
+                        "Mkocansey\\Bladewind\\ThemeSwitcher\\BladewindThemeSwitcherServiceProvider",
                         "Mkocansey\\Bladewind\\BladewindServiceProvider"
                     ]
                 }
             },
             "autoload": {
+                "files": [
+                    "packages/core/src/BladewindHelpers.php"
+                ],
                 "psr-4": {
-                    "Mkocansey\\Bladewind\\": "src/"
+                    "Mkocansey\\Bladewind\\": "packages/meta/src/",
+                    "Mkocansey\\Bladewind\\Tab\\": "packages/tab/src/",
+                    "Mkocansey\\Bladewind\\Tag\\": "packages/tag/src/",
+                    "Mkocansey\\Bladewind\\Card\\": "packages/card/src/",
+                    "Mkocansey\\Bladewind\\Code\\": "packages/code/src/",
+                    "Mkocansey\\Bladewind\\Core\\": "packages/core/src/",
+                    "Mkocansey\\Bladewind\\Icon\\": "packages/icon/src/",
+                    "Mkocansey\\Bladewind\\Alert\\": "packages/alert/src/",
+                    "Mkocansey\\Bladewind\\Chart\\": "packages/chart/src/",
+                    "Mkocansey\\Bladewind\\Input\\": "packages/input/src/",
+                    "Mkocansey\\Bladewind\\Modal\\": "packages/modal/src/",
+                    "Mkocansey\\Bladewind\\Radio\\": "packages/radio/src/",
+                    "Mkocansey\\Bladewind\\Table\\": "packages/table/src/",
+                    "Mkocansey\\Bladewind\\Avatar\\": "packages/avatar/src/",
+                    "Mkocansey\\Bladewind\\Button\\": "packages/button/src/",
+                    "Mkocansey\\Bladewind\\Number\\": "packages/number/src/",
+                    "Mkocansey\\Bladewind\\Rating\\": "packages/rating/src/",
+                    "Mkocansey\\Bladewind\\Script\\": "packages/script/src/",
+                    "Mkocansey\\Bladewind\\Select\\": "packages/select/src/",
+                    "Mkocansey\\Bladewind\\Slider\\": "packages/slider/src/",
+                    "Mkocansey\\Bladewind\\Toggle\\": "packages/toggle/src/",
+                    "Mkocansey\\Bladewind\\Spinner\\": "packages/spinner/src/",
+                    "Mkocansey\\Bladewind\\Checkbox\\": "packages/checkbox/src/",
+                    "Mkocansey\\Bladewind\\Dropmenu\\": "packages/dropmenu/src/",
+                    "Mkocansey\\Bladewind\\Listview\\": "packages/listview/src/",
+                    "Mkocansey\\Bladewind\\Progress\\": "packages/progress/src/",
+                    "Mkocansey\\Bladewind\\Textarea\\": "packages/textarea/src/",
+                    "Mkocansey\\Bladewind\\Timeline\\": "packages/timeline/src/",
+                    "Mkocansey\\Bladewind\\Accordion\\": "packages/accordion/src/",
+                    "Mkocansey\\Bladewind\\Statistic\\": "packages/statistic/src/",
+                    "Mkocansey\\Bladewind\\Checkcards\\": "packages/checkcards/src/",
+                    "Mkocansey\\Bladewind\\Datepicker\\": "packages/datepicker/src/",
+                    "Mkocansey\\Bladewind\\EmptyState\\": "packages/empty-state/src/",
+                    "Mkocansey\\Bladewind\\Filepicker\\": "packages/filepicker/src/",
+                    "Mkocansey\\Bladewind\\Pagination\\": "packages/pagination/src/",
+                    "Mkocansey\\Bladewind\\Timepicker\\": "packages/timepicker/src/",
+                    "Mkocansey\\Bladewind\\Colorpicker\\": "packages/colorpicker/src/",
+                    "Mkocansey\\Bladewind\\ContactCard\\": "packages/contact-card/src/",
+                    "Mkocansey\\Bladewind\\ThemeSwitcher\\": "packages/theme-switcher/src/",
+                    "Mkocansey\\Bladewind\\CenteredContent\\": "packages/centered-content/src/",
+                    "Mkocansey\\Bladewind\\HorizontalLineGraph\\": "packages/horizontal-line-graph/src/"
                 }
             },
-            "scripts": {
-                "post-update-cmd": [
-                    "@php -r \"if (file_exists('artisan')) passthru('php artisan vendor:publish --tag=bladewind-public --force');\"",
-                    "@php -r \"if (file_exists('artisan')) passthru('php artisan vendor:publish --tag=bladewind-lang --force');\""
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -2049,29 +2197,32 @@
                     "email": "mike@bladewindui.com"
                 }
             ],
-            "description": "Laravel UI Components using TailwindCSS, Blade Templates and vanilla Javascript",
+            "description": "BladewindUI — elegant Laravel Blade UI components powered by TailwindCSS",
             "keywords": [
-                "blade components",
+                "Ui Components",
+                "blade",
+                "bladewindui",
                 "laravel",
-                "tailwindcss",
-                "ui components"
+                "tailwindcss"
             ],
-            "transport-options": {
-                "relative": false
-            }
+            "support": {
+                "issues": "https://github.com/mkocansey/bladewind/issues",
+                "source": "https://github.com/mkocansey/bladewind/tree/v4.1.0"
+            },
+            "time": "2026-06-08T08:27:12+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -2089,7 +2240,7 @@
                 "graylog2/gelf-php": "^1.4.2 || ^2.0",
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
+                "mongodb/mongodb": "^1.8 || ^2.0",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.8",
                 "phpstan/phpstan": "^2",
@@ -2149,7 +2300,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -2161,20 +2312,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.10.3",
+            "version": "3.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f"
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f",
-                "reference": "8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
                 "shasum": ""
             },
             "require": {
@@ -2182,9 +2333,9 @@
                 "ext-json": "*",
                 "php": "^8.1",
                 "psr/clock": "^1.0",
-                "symfony/clock": "^6.3.12 || ^7.0",
+                "symfony/clock": "^6.3.12 || ^7.0 || ^8.0",
                 "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0"
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0 || ^8.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -2198,7 +2349,7 @@
                 "phpstan/extension-installer": "^1.4.3",
                 "phpstan/phpstan": "^2.1.22",
                 "phpunit/phpunit": "^10.5.53",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
             },
             "bin": [
                 "bin/carbon"
@@ -2241,14 +2392,14 @@
                 }
             ],
             "description": "An API extension for DateTime that supports 281 different languages.",
-            "homepage": "https://carbon.nesbot.com",
+            "homepage": "https://carbonphp.github.io/carbon/",
             "keywords": [
                 "date",
                 "datetime",
                 "time"
             ],
             "support": {
-                "docs": "https://carbon.nesbot.com/docs",
+                "docs": "https://carbonphp.github.io/carbon/guide/getting-started/introduction.html",
                 "issues": "https://github.com/CarbonPHP/carbon/issues",
                 "source": "https://github.com/CarbonPHP/carbon"
             },
@@ -2266,29 +2417,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-06T13:39:36+00:00"
+            "time": "2026-04-07T09:57:54+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.2",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/da801d52f0354f70a638673c4a0f04e16529431d",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^4.0",
-                "php": "8.1 - 8.4"
+                "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^1.0",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -2298,6 +2451,9 @@
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -2326,26 +2482,26 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.2"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2024-10-06T23:10:23+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.8",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c930ca4e3cf4f17dcfb03037703679d2396d2ede",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.5"
+                "php": "8.2 - 8.5"
             },
             "conflict": {
                 "nette/finder": "<3",
@@ -2353,8 +2509,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -2368,7 +2526,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2415,22 +2573,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.8"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2025-08-06T21:43:34+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -2473,37 +2631,37 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "dfa08f390e509967a15c22493dc0bac5733d9123"
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/dfa08f390e509967a15c22493dc0bac5733d9123",
-                "reference": "dfa08f390e509967a15c22493dc0bac5733d9123",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/712a31b768f5daea284c2169a7d227031001b9a8",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^8.2",
-                "symfony/console": "^7.2.6"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "require-dev": {
-                "illuminate/console": "^11.44.7",
-                "laravel/pint": "^1.22.0",
+                "illuminate/console": "^11.47.0",
+                "laravel/pint": "^1.27.1",
                 "mockery/mockery": "^1.6.12",
-                "pestphp/pest": "^2.36.0 || ^3.8.2",
-                "phpstan/phpstan": "^1.12.25",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.3.2",
+                "phpstan/phpstan": "^1.12.32",
                 "phpstan/phpstan-strict-rules": "^1.6.2",
-                "symfony/var-dumper": "^7.2.6",
+                "symfony/var-dumper": "^7.3.5 || ^8.0.4",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
             "type": "library",
@@ -2535,7 +2693,7 @@
                     "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Its like Tailwind CSS, but for the console.",
+            "description": "It's like Tailwind CSS, but for the console.",
             "keywords": [
                 "cli",
                 "console",
@@ -2546,7 +2704,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.1"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -2562,91 +2720,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-08T08:14:37+00:00"
-        },
-        {
-            "name": "phiki/phiki",
-            "version": "v2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phikiphp/phiki.git",
-                "reference": "160785c50c01077780ab217e5808f00ab8f05a13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phikiphp/phiki/zipball/160785c50c01077780ab217e5808f00ab8f05a13",
-                "reference": "160785c50c01077780ab217e5808f00ab8f05a13",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "league/commonmark": "^2.5.3",
-                "php": "^8.2",
-                "psr/simple-cache": "^3.0"
-            },
-            "require-dev": {
-                "illuminate/support": "^11.45",
-                "laravel/pint": "^1.18.1",
-                "orchestra/testbench": "^9.15",
-                "pestphp/pest": "^3.5.1",
-                "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^2.0",
-                "symfony/var-dumper": "^7.1.6"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Phiki\\Adapters\\Laravel\\PhikiServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Phiki\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ryan Chandler",
-                    "email": "support@ryangjchandler.co.uk",
-                    "homepage": "https://ryangjchandler.co.uk",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Syntax highlighting using TextMate grammars in PHP.",
-            "support": {
-                "issues": "https://github.com/phikiphp/phiki/issues",
-                "source": "https://github.com/phikiphp/phiki/tree/v2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/ryangjchandler",
-                    "type": "github"
-                },
-                {
-                    "url": "https://buymeacoffee.com/ryangjchandler",
-                    "type": "other"
-                }
-            ],
-            "time": "2025-09-20T17:21:02+00:00"
+            "time": "2026-02-16T23:10:27+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
                 "shasum": ""
             },
             "require": {
@@ -2696,7 +2783,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
             },
             "funding": [
                 {
@@ -2708,7 +2795,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-21T11:53:16+00:00"
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "psr/clock",
@@ -3124,16 +3211,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.12",
+            "version": "v0.12.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "cd23863404a40ccfaf733e3af4db2b459837f7e7"
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/cd23863404a40ccfaf733e3af4db2b459837f7e7",
-                "reference": "cd23863404a40ccfaf733e3af4db2b459837f7e7",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
                 "shasum": ""
             },
             "require": {
@@ -3141,18 +3228,19 @@
                 "ext-tokenizer": "*",
                 "nikic/php-parser": "^5.0 || ^4.0",
                 "php": "^8.0 || ^7.4",
-                "symfony/console": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
-                "symfony/var-dumper": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
+                "symfony/console": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
             },
             "conflict": {
                 "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.2"
+                "bamarni/composer-bin-plugin": "^1.2",
+                "composer/class-map-generator": "^1.6"
             },
             "suggest": {
+                "composer/class-map-generator": "Improved tab completion performance with better class discovery.",
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
-                "ext-pdo-sqlite": "The doc command requires SQLite to work.",
                 "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well."
             },
             "bin": [
@@ -3196,9 +3284,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.12"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
             },
-            "time": "2025-09-20T13:46:31+00:00"
+            "time": "2026-05-23T13:41:31+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3322,20 +3410,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.1",
+            "version": "4.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "81f941f6f729b1e3ceea61d9d014f8b6c6800440"
+                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/81f941f6f729b1e3ceea61d9d014f8b6c6800440",
-                "reference": "81f941f6f729b1e3ceea61d9d014f8b6c6800440",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
+                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -3394,28 +3482,27 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.1"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
-            "time": "2025-09-04T20:59:21+00:00"
+            "time": "2025-12-14T04:43:48+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.3.0",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
-                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "psr/clock": "^1.0",
-                "symfony/polyfill-php83": "^1.28"
+                "php": ">=8.4.1",
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -3454,7 +3541,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.3.0"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3466,24 +3553,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.3",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
-                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -3491,7 +3582,7 @@
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2"
+                "symfony/string": "^7.2|^8.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<6.4",
@@ -3505,16 +3596,16 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/stopwatch": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3548,7 +3639,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.3"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3568,24 +3659,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-25T06:35:40+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.3.0",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "601a5ce9aaad7bf10797e3663faefce9e26c24e2"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/601a5ce9aaad7bf10797e3663faefce9e26c24e2",
-                "reference": "601a5ce9aaad7bf10797e3663faefce9e26c24e2",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -3617,7 +3708,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.3.0"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3629,24 +3720,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -3659,7 +3754,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3684,7 +3779,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3696,40 +3791,45 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.3.2",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "0b31a944fcd8759ae294da4d2808cbc53aebd0c3"
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/0b31a944fcd8759ae294da4d2808cbc53aebd0c3",
-                "reference": "0b31a944fcd8759ae294da4d2808cbc53aebd0c3",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/polyfill-php85": "^1.32",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "conflict": {
                 "symfony/deprecation-contracts": "<2.5",
                 "symfony/http-kernel": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
                 "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
@@ -3761,7 +3861,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.3.2"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -3781,28 +3881,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-07T08:17:57+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.3.3",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191"
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7dc69e71de420ac04bc9ab830cf3ffebba48191",
-                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -3811,13 +3912,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3845,7 +3947,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3865,20 +3967,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -3892,7 +3994,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3925,7 +4027,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3937,31 +4039,35 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.3.2",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe"
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2a6614966ba1074fa93dae0bc804227422df4dfe",
-                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0"
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3989,7 +4095,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.3.2"
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4009,27 +4115,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.3.3",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "7475561ec27020196c49bb7c4f178d33d7d3dc00"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/7475561ec27020196c49bb7c4f178d33d7d3dc00",
-                "reference": "7475561ec27020196c49bb7c4f178d33d7d3dc00",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php83": "^1.27"
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
             },
             "conflict": {
                 "doctrine/dbal": "<3.6",
@@ -4038,13 +4143,13 @@
             "require-dev": {
                 "doctrine/dbal": "^3.6|^4",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.4.12|^7.1.5",
-                "symfony/clock": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/mime": "^6.4|^7.0",
-                "symfony/rate-limiter": "^6.4|^7.0"
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4072,7 +4177,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.3.3"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4092,29 +4197,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T08:04:18+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.3.3",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/72c304de37e1a1cec6d5d12b81187ebd4850a17b",
-                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^7.3",
-                "symfony/http-foundation": "^7.3",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -4124,6 +4229,7 @@
                 "symfony/console": "<6.4",
                 "symfony/dependency-injection": "<6.4",
                 "symfony/doctrine-bridge": "<6.4",
+                "symfony/flex": "<2.10",
                 "symfony/form": "<6.4",
                 "symfony/http-client": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
@@ -4141,27 +4247,27 @@
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^6.4|^7.0",
-                "symfony/clock": "^6.4|^7.0",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/console": "^6.4|^7.0",
-                "symfony/css-selector": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/dom-crawler": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/finder": "^6.4|^7.0",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/css-selector": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
+                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/property-access": "^7.1",
-                "symfony/routing": "^6.4|^7.0",
-                "symfony/serializer": "^7.1",
-                "symfony/stopwatch": "^6.4|^7.0",
-                "symfony/translation": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^7.1|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^7.1|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^6.4|^7.0",
-                "symfony/validator": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0",
-                "symfony/var-exporter": "^6.4|^7.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0",
                 "twig/twig": "^3.12"
             },
             "type": "library",
@@ -4190,7 +4296,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.3.3"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4210,20 +4316,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-29T08:23:45+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.3.3",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575"
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/a32f3f45f1990db8c4341d5122a7d3a381c7e575",
-                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
                 "shasum": ""
             },
             "require": {
@@ -4231,8 +4337,8 @@
                 "php": ">=8.2",
                 "psr/event-dispatcher": "^1",
                 "psr/log": "^1|^2|^3",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/mime": "^7.2",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^7.2|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -4243,10 +4349,10 @@
                 "symfony/twig-bridge": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0",
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/twig-bridge": "^6.4|^7.0"
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4274,7 +4380,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.3.3"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -4294,43 +4400,44 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.3.2",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/e0a0f859148daf1edf6c60b398eb40bfc96697d1",
-                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
                 "symfony/mailer": "<6.4",
                 "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/property-access": "^6.4|^7.0",
-                "symfony/property-info": "^6.4|^7.0",
-                "symfony/serializer": "^6.4.3|^7.0.3"
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4362,7 +4469,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.3.2"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4382,20 +4489,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -4445,7 +4552,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4465,20 +4572,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -4527,7 +4634,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4547,20 +4654,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -4614,7 +4721,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4634,20 +4741,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -4699,7 +4806,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -4719,20 +4826,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -4784,7 +4891,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4804,20 +4911,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -4868,7 +4975,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4888,20 +4995,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "8339098cae28673c15cce00d80734af0453054e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
+                "reference": "8339098cae28673c15cce00d80734af0453054e2",
                 "shasum": ""
             },
             "require": {
@@ -4948,7 +5055,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4968,20 +5075,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -5028,7 +5135,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5048,20 +5155,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -5108,7 +5215,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5128,20 +5235,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -5191,7 +5298,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5211,20 +5318,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.3.3",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/32241012d521e2e8a9d713adb0812bb773b907f1",
-                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -5256,7 +5363,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.3.3"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5276,20 +5383,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-18T09:42:54+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.3.2",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "7614b8ca5fa89b9cd233e21b627bfc5774f586e4"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/7614b8ca5fa89b9cd233e21b627bfc5774f586e4",
-                "reference": "7614b8ca5fa89b9cd233e21b627bfc5774f586e4",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -5303,11 +5410,11 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/yaml": "^6.4|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5341,7 +5448,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.3.2"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5361,20 +5468,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:36:08+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -5392,7 +5499,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5428,7 +5535,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5440,43 +5547,46 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-25T09:37:31+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.3",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
-                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/intl": "^6.4|^7.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5515,7 +5625,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.3"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5535,38 +5645,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-25T06:35:40+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.3.3",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "e0837b4cbcef63c754d89a4806575cada743a38d"
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/e0837b4cbcef63c754d89a4806575cada743a38d",
-                "reference": "e0837b4cbcef63c754d89a4806575cada743a38d",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.5|^3.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation-contracts": "^3.6.1"
             },
             "conflict": {
                 "nikic/php-parser": "<5.0",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/service-contracts": "<2.5",
-                "symfony/twig-bundle": "<6.4",
-                "symfony/yaml": "<6.4"
+                "symfony/service-contracts": "<2.5"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
@@ -5574,17 +5677,17 @@
             "require-dev": {
                 "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/console": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/finder": "^6.4|^7.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/intl": "^6.4|^7.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^6.4|^7.0",
+                "symfony/routing": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5615,7 +5718,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.3.3"
+                "source": "https://github.com/symfony/translation/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5635,20 +5738,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-01T21:02:37+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
-                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -5661,7 +5764,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5697,7 +5800,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5709,24 +5812,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-27T08:32:26+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.3.1",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "a69f69f3159b852651a6bf45a9fdd149520525bb"
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/a69f69f3159b852651a6bf45a9fdd149520525bb",
-                "reference": "a69f69f3159b852651a6bf45a9fdd149520525bb",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/2676b524340abcfe4d6151ec698463cebafee439",
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439",
                 "shasum": ""
             },
             "require": {
@@ -5734,7 +5841,7 @@
                 "symfony/polyfill-uuid": "^1.15"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0"
+                "symfony/console": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5771,7 +5878,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.3.1"
+                "source": "https://github.com/symfony/uid/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -5783,24 +5890,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2026-04-30T15:19:22+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.3",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f"
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
-                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
                 "shasum": ""
             },
             "require": {
@@ -5812,10 +5923,10 @@
                 "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/uid": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
                 "twig/twig": "^3.12"
             },
             "bin": [
@@ -5854,7 +5965,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5874,27 +5985,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2026-03-30T13:44:50+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "0d72ac1c00084279c1816675284073c5a337c20d"
+                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/0d72ac1c00084279c1816675284073c5a337c20d",
-                "reference": "0d72ac1c00084279c1816675284073c5a337c20d",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/f0292ccf0ec75843d65027214426b6b163b48b41",
+                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "php": "^7.4 || ^8.0",
-                "symfony/css-selector": "^5.4 || ^6.0 || ^7.0"
+                "symfony/css-selector": "^5.4 || ^6.0 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^2.0",
@@ -5927,32 +6038,32 @@
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "support": {
                 "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
-                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.3.0"
+                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.4.0"
             },
-            "time": "2024-12-21T16:25:41+00:00"
+            "time": "2025-12-02T11:56:42+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.2",
+            "version": "v5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.3",
+                "graham-campbell/result-type": "^1.1.4",
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3",
-                "symfony/polyfill-ctype": "^1.24",
-                "symfony/polyfill-mbstring": "^1.24",
-                "symfony/polyfill-php80": "^1.24"
+                "phpoption/phpoption": "^1.9.5",
+                "symfony/polyfill-ctype": "^1.26",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/polyfill-php80": "^1.26"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -6001,7 +6112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
             },
             "funding": [
                 {
@@ -6013,27 +6124,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-30T23:37:27+00:00"
+            "time": "2025-12-27T19:49:13+00:00"
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -6063,7 +6174,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -6087,65 +6198,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
-            },
-            "time": "2022-06-03T18:03:27+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "packages-dev": [
@@ -6390,37 +6443,38 @@
         },
         {
             "name": "laravel/pail",
-            "version": "v1.2.3",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "8cc3d575c1f0e57eeb923f366a37528c50d2385a"
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/8cc3d575c1f0e57eeb923f366a37528c50d2385a",
-                "reference": "8cc3d575c1f0e57eeb923f366a37528c50d2385a",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/2f7d27dada8effc48b8c424445a69cca7007daaa",
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "illuminate/console": "^10.24|^11.0|^12.0",
-                "illuminate/contracts": "^10.24|^11.0|^12.0",
-                "illuminate/log": "^10.24|^11.0|^12.0",
-                "illuminate/process": "^10.24|^11.0|^12.0",
-                "illuminate/support": "^10.24|^11.0|^12.0",
+                "illuminate/console": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/log": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/process": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.24|^11.0|^12.0|^13.0",
                 "nunomaduro/termwind": "^1.15|^2.0",
                 "php": "^8.2",
-                "symfony/console": "^6.0|^7.0"
+                "symfony/console": "^6.0|^7.0|^8.0"
             },
             "require-dev": {
-                "laravel/framework": "^10.24|^11.0|^12.0",
+                "laravel/framework": "^10.24|^11.0|^12.0|^13.0",
                 "laravel/pint": "^1.13",
-                "orchestra/testbench-core": "^8.13|^9.0|^10.0",
-                "pestphp/pest": "^2.20|^3.0",
-                "pestphp/pest-plugin-type-coverage": "^2.3|^3.0",
+                "orchestra/testbench-core": "^8.13|^9.17|^10.8|^11.0",
+                "pestphp/pest": "^2.20|^3.0|^4.0",
+                "pestphp/pest-plugin-type-coverage": "^2.3|^3.0|^4.0",
                 "phpstan/phpstan": "^1.12.27",
-                "symfony/var-dumper": "^6.3|^7.0"
+                "symfony/var-dumper": "^6.3|^7.0|^8.0",
+                "symfony/yaml": "^6.3|^7.0|^8.0"
             },
             "type": "library",
             "extra": {
@@ -6465,20 +6519,20 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2025-06-05T13:55:57+00:00"
+            "time": "2026-05-20T22:24:57+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.25.1",
+            "version": "v1.29.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "5016e263f95d97670d71b9a987bd8996ade6d8d9"
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/5016e263f95d97670d71b9a987bd8996ade6d8d9",
-                "reference": "5016e263f95d97670d71b9a987bd8996ade6d8d9",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80",
                 "shasum": ""
             },
             "require": {
@@ -6489,13 +6543,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.87.2",
-                "illuminate/view": "^11.46.0",
-                "larastan/larastan": "^3.7.1",
-                "laravel-zero/framework": "^11.45.0",
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "illuminate/view": "^12.56.0",
+                "larastan/larastan": "^3.9.6",
+                "laravel-zero/framework": "^12.1.0",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.1",
-                "pestphp/pest": "^2.36.0"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.3"
             },
             "bin": [
                 "builds/pint"
@@ -6521,6 +6576,7 @@
             "description": "An opinionated code formatter for PHP.",
             "homepage": "https://laravel.com",
             "keywords": [
+                "dev",
                 "format",
                 "formatter",
                 "lint",
@@ -6531,33 +6587,33 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-09-19T02:57:12+00:00"
+            "time": "2026-04-20T15:26:14+00:00"
         },
         {
             "name": "laravel/sail",
-            "version": "v1.46.0",
+            "version": "v1.62.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "eb90c4f113c4a9637b8fdd16e24cfc64f2b0ae6e"
+                "reference": "3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/eb90c4f113c4a9637b8fdd16e24cfc64f2b0ae6e",
-                "reference": "eb90c4f113c4a9637b8fdd16e24cfc64f2b0ae6e",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e",
+                "reference": "3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^9.52.16|^10.0|^11.0|^12.0",
-                "illuminate/contracts": "^9.52.16|^10.0|^11.0|^12.0",
-                "illuminate/support": "^9.52.16|^10.0|^11.0|^12.0",
+                "illuminate/console": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.0",
-                "symfony/console": "^6.0|^7.0",
-                "symfony/yaml": "^6.0|^7.0"
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/yaml": "^6.0|^7.0|^8.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-                "phpstan/phpstan": "^1.10"
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+                "phpstan/phpstan": "^2.0"
             },
             "bin": [
                 "bin/sail"
@@ -6594,7 +6650,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2025-09-23T13:44:39+00:00"
+            "time": "2026-05-27T04:02:01+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -6741,39 +6797,36 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.2",
+            "version": "v8.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "60207965f9b7b7a4ce15a0f75d57f9dadb105bdb"
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/60207965f9b7b7a4ce15a0f75d57f9dadb105bdb",
-                "reference": "60207965f9b7b7a4ce15a0f75d57f9dadb105bdb",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/716af8f95a470e9094cfca09ed897b023be191a5",
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.18.1",
-                "nunomaduro/termwind": "^2.3.1",
+                "filp/whoops": "^2.18.4",
+                "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.3.0"
+                "symfony/console": "^7.4.8 || ^8.0.8"
             },
             "conflict": {
-                "laravel/framework": "<11.44.2 || >=13.0.0",
-                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
+                "laravel/framework": "<11.48.0 || >=14.0.0",
+                "phpunit/phpunit": "<11.5.50 || >=14.0.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.4.2",
-                "laravel/framework": "^11.44.2 || ^12.18",
-                "laravel/pint": "^1.22.1",
-                "laravel/sail": "^1.43.1",
-                "laravel/sanctum": "^4.1.1",
-                "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2",
-                "sebastian/environment": "^7.2.1 || ^8.0"
+                "brianium/paratest": "^7.8.5",
+                "larastan/larastan": "^3.9.6",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.5.0",
+                "laravel/pint": "^1.29.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.2.1",
+                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.3.0"
             },
             "type": "library",
             "extra": {
@@ -6836,7 +6889,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-06-25T02:12:12+00:00"
+            "time": "2026-04-21T14:04:20+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -6958,35 +7011,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.11",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4"
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
-                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.4.0",
+                "nikic/php-parser": "^5.7.0",
                 "php": ">=8.2",
                 "phpunit/php-file-iterator": "^5.1.0",
                 "phpunit/php-text-template": "^4.0.1",
                 "sebastian/code-unit-reverse-lookup": "^4.0.1",
                 "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.0",
+                "sebastian/environment": "^7.2.1",
                 "sebastian/lines-of-code": "^3.0.1",
                 "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.2.3"
+                "theseer/tokenizer": "^1.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.2"
+                "phpunit/phpunit": "^11.5.46"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -7024,7 +7077,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.11"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
             },
             "funding": [
                 {
@@ -7044,32 +7097,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-27T14:37:49+00:00"
+            "time": "2025-12-24T07:01:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -7097,15 +7150,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T05:02:59+00:00"
+            "time": "2026-02-02T13:52:54+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -7293,16 +7358,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.41",
+            "version": "11.5.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b42782bcb947d2c197aea42ce9714ee2d974b283"
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b42782bcb947d2c197aea42ce9714ee2d974b283",
-                "reference": "b42782bcb947d2c197aea42ce9714ee2d974b283",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
                 "shasum": ""
             },
             "require": {
@@ -7316,19 +7381,20 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.11",
-                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
                 "phpunit/php-invoker": "^5.0.1",
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
                 "sebastian/cli-parser": "^3.0.2",
                 "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.2",
+                "sebastian/comparator": "^6.3.3",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.1",
                 "sebastian/exporter": "^6.3.2",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
                 "sebastian/type": "^5.1.3",
                 "sebastian/version": "^5.0.2",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -7374,7 +7440,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.41"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
             },
             "funding": [
                 {
@@ -7398,7 +7464,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:32:10+00:00"
+            "time": "2026-02-18T12:37:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -7572,16 +7638,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.2",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8"
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85c77556683e6eee4323e4c5468641ca0237e2e8",
-                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
                 "shasum": ""
             },
             "require": {
@@ -7640,7 +7706,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
             },
             "funding": [
                 {
@@ -7660,7 +7726,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T08:07:46+00:00"
+            "time": "2026-01-24T09:26:40+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -8440,28 +8506,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.3.3",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0"
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -8492,7 +8558,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -8512,20 +8578,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-27T11:34:33+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -8554,7 +8620,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -8562,14 +8628,12 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "mkocansey/bladewind": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7019e11ec0745426c1890818a486ad1",
+    "content-hash": "12bb08f52f661e26e0bbe6e2aace3a4c",
     "packages": [
         {
             "name": "brick/math",

--- a/generate-mcp.php
+++ b/generate-mcp.php
@@ -1,0 +1,282 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * BladewindUI MCP Documentation Generator
+ *
+ * Converts a BladewindUI doc blade file into a clean MCP-readable markdown file.
+ *
+ * Usage:
+ *   php generate-mcp.php <component-name> [--dry-run] [--update-index]
+ *
+ * Examples:
+ *   php generate-mcp.php button
+ *   php generate-mcp.php horizontal-line-graph
+ *   php generate-mcp.php my-new-component --update-index
+ *   php generate-mcp.php button --dry-run
+ *
+ * Environment:
+ *   ANTHROPIC_API_KEY  required — your Anthropic API key
+ */
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+$BLADE_DIR = __DIR__ . '/resources/views/docs';
+$MCP_DIR   = __DIR__ . '/mcp';
+$MODEL     = 'claude-opus-4-7';
+
+// Blade files where the filename differs from the component slug
+$FILENAME_OVERRIDES = [
+    'empty-state' => 'emptystate',
+];
+
+// ── Argument parsing ─────────────────────────────────────────────────────────
+
+$args        = array_slice($argv, 1);
+$dryRun      = in_array('--dry-run', $args);
+$updateIndex = in_array('--update-index', $args);
+$args        = array_filter($args, fn($a) => !str_starts_with($a, '--'));
+$args        = array_values($args);
+
+if (count($args) === 0) {
+    fwrite(STDERR, "Usage: php generate-mcp.php <component-name> [--dry-run] [--update-index]\n");
+    exit(1);
+}
+
+$componentSlug = strtolower(trim($args[0]));
+
+// ── Locate the blade file ────────────────────────────────────────────────────
+
+$apiKey = getenv('ANTHROPIC_API_KEY');
+if (!$apiKey) {
+    fwrite(STDERR, "Error: ANTHROPIC_API_KEY environment variable is not set.\n");
+    exit(1);
+}
+
+$bladeName     = $FILENAME_OVERRIDES[$componentSlug] ?? $componentSlug;
+$bladeCandidates = [
+    "$BLADE_DIR/{$bladeName}.blade.php",
+    "$BLADE_DIR/" . str_replace('-', '', $bladeName) . ".blade.php",
+    "$BLADE_DIR/" . str_replace('-', '_', $bladeName) . ".blade.php",
+];
+
+$bladePath = null;
+foreach ($bladeCandidates as $candidate) {
+    if (file_exists($candidate)) {
+        $bladePath = $candidate;
+        break;
+    }
+}
+
+if (!$bladePath) {
+    fwrite(STDERR, "Error: Could not find blade file for '{$componentSlug}'.\n");
+    fwrite(STDERR, "Tried:\n");
+    foreach ($bladeCandidates as $c) {
+        fwrite(STDERR, "  $c\n");
+    }
+    exit(1);
+}
+
+$outputPath = "$MCP_DIR/{$componentSlug}.md";
+
+echo "Source : $bladePath\n";
+echo "Output : $outputPath\n";
+if ($dryRun) echo "(dry-run — no files will be written)\n";
+echo "\n";
+
+// ── Read source ──────────────────────────────────────────────────────────────
+
+$bladeContent = file_get_contents($bladePath);
+$fileSize     = strlen($bladeContent);
+echo "Source size: " . number_format($fileSize) . " bytes\n";
+
+// ── System prompt ────────────────────────────────────────────────────────────
+
+$systemPrompt = <<<'SYSTEM'
+You are a technical documentation converter for BladewindUI, a Laravel Blade component library.
+
+Your job is to convert a BladewindUI documentation blade file into a clean, MCP-readable Markdown file. The output will be consumed by an MCP server to help AI assistants understand how to use each component.
+
+## Output format
+
+Always produce exactly this structure:
+
+```
+---
+title: [Component Name] Component
+component: x-bladewind::[component-tag]
+url: /component/[slug]
+---
+
+# [Component Name]
+
+[1-2 sentence description of what the component does and when to use it]
+
+## Basic Usage
+
+```blade
+[minimal working example]
+```
+
+## [Section Heading]
+
+[prose explaining the feature]
+
+```blade
+[code example(s)]
+```
+
+...more sections as needed...
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | default | Description. `value1` \| `value2` |
+
+## Full Example
+
+```blade
+[complete example with all attributes shown]
+```
+```
+
+## Rules
+
+1. **Code blocks**: Use ` ```blade ` for Blade/HTML examples, ` ```php ` for PHP, ` ```js ` for JavaScript. Never use ` ```markup ` or ` ```html `.
+
+2. **HTML entity decoding**: All `<pre><code>` blocks in the source use HTML entities. Decode them in the output:
+   - `&lt;` → `<`
+   - `&gt;` → `>`
+   - `&amp;` → `&`
+   - `&#123;` → `{`
+   - `&#125;` → `}`
+
+3. **Consolidate colour examples**: Instead of one code block per colour, show one block listing all colours as separate component calls. Do not repeat the same structure 10 times.
+
+4. **Omit**: `@include`, live component previews (non-code blade tags), `<x-slot:side_nav>`, `<x-slot name="scripts">`, `@php` blocks that just set up demo data, `x-bladewind::alert` tips (convert to prose instead), layout boilerplate.
+
+5. **Attribute tables**: Extract from the blade's `<x-bladewind::table>` attributes sections. Use pipe-escaped values like `true` \| `false`. Wrap option values in backticks.
+
+6. **Two sub-components**: If the doc covers multiple sub-components (e.g. `processing` + `process-complete`), include both attribute tables under separate `###` headings.
+
+7. **Frontmatter**: Derive `title`, `component`, and `url` from the page title and component tags in the source. The `url` is always `/component/[slug]`.
+
+8. **Be concise**: Write clear, direct prose. No filler sentences.
+
+9. **Output only markdown**: Do not include any explanation, preamble, or closing commentary. Output the markdown document and nothing else.
+SYSTEM;
+
+// ── User prompt ───────────────────────────────────────────────────────────────
+
+$componentTitle = ucwords(str_replace('-', ' ', $componentSlug));
+
+$userPrompt = <<<PROMPT
+Convert the following BladewindUI documentation blade file for the **{$componentTitle}** component into a clean MCP markdown file.
+
+The component slug is `{$componentSlug}`, so the frontmatter url should be `/component/{$componentSlug}`.
+
+Source file:
+```
+{$bladeContent}
+```
+PROMPT;
+
+// ── Call Claude API ───────────────────────────────────────────────────────────
+
+echo "Calling Claude API ({$MODEL})...\n";
+
+$payload = json_encode([
+    'model'      => $MODEL,
+    'max_tokens' => 8192,
+    'system'     => $systemPrompt,
+    'messages'   => [
+        ['role' => 'user', 'content' => $userPrompt],
+    ],
+]);
+
+$ch = curl_init('https://api.anthropic.com/v1/messages');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => $payload,
+    CURLOPT_HTTPHEADER     => [
+        'Content-Type: application/json',
+        'x-api-key: ' . $apiKey,
+        'anthropic-version: 2023-06-01',
+    ],
+    CURLOPT_TIMEOUT        => 300,
+]);
+
+$response = curl_exec($ch);
+$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$curlError = curl_error($ch);
+curl_close($ch);
+
+if ($curlError) {
+    fwrite(STDERR, "cURL error: $curlError\n");
+    exit(1);
+}
+
+if ($httpCode !== 200) {
+    fwrite(STDERR, "API error (HTTP $httpCode):\n$response\n");
+    exit(1);
+}
+
+$data = json_decode($response, true);
+
+if (!isset($data['content'][0]['text'])) {
+    fwrite(STDERR, "Unexpected API response structure:\n$response\n");
+    exit(1);
+}
+
+$markdown = trim($data['content'][0]['text']);
+
+$inputTokens  = $data['usage']['input_tokens'] ?? '?';
+$outputTokens = $data['usage']['output_tokens'] ?? '?';
+echo "Tokens: {$inputTokens} in / {$outputTokens} out\n\n";
+
+// ── Write output ──────────────────────────────────────────────────────────────
+
+if ($dryRun) {
+    echo "── Generated markdown (dry-run) ──────────────────────────────────────\n";
+    echo $markdown . "\n";
+    echo "──────────────────────────────────────────────────────────────────────\n";
+    exit(0);
+}
+
+if (!is_dir($MCP_DIR)) {
+    mkdir($MCP_DIR, 0755, true);
+}
+
+file_put_contents($outputPath, $markdown . "\n");
+echo "Written: $outputPath\n";
+
+// ── Update index.md ───────────────────────────────────────────────────────────
+
+if ($updateIndex) {
+    $indexPath = "$MCP_DIR/index.md";
+
+    if (!file_exists($indexPath)) {
+        echo "Warning: index.md not found at $indexPath — skipping index update.\n";
+    } else {
+        $indexContent = file_get_contents($indexPath);
+
+        // Extract component tag from the generated markdown frontmatter
+        preg_match('/^component:\s*(.+)$/m', $markdown, $tagMatch);
+        $componentTag = trim($tagMatch[1] ?? "x-bladewind::{$componentSlug}");
+
+        $newRow = "| {$componentTitle} | `{$componentTag}` | [{$componentSlug}.md]({$componentSlug}.md) |";
+
+        if (str_contains($indexContent, "{$componentSlug}.md")) {
+            echo "Index: entry for '{$componentSlug}' already exists — skipping.\n";
+        } else {
+            // Append before the final newline of the table
+            $indexContent = rtrim($indexContent) . "\n" . $newRow . "\n";
+            file_put_contents($indexPath, $indexContent);
+            echo "Index: added entry for '{$componentSlug}'.\n";
+        }
+    }
+}
+
+echo "\nDone.\n";

--- a/mcp/accordion.md
+++ b/mcp/accordion.md
@@ -1,0 +1,171 @@
+---
+title: Accordion Component
+component: x-bladewind::accordion
+url: /component/accordion
+---
+
+# Accordion
+
+The accordion component allows users to expand or collapse sections of content. It's commonly used to organize information in a compact, accessible way. Each section typically has a header that can be clicked to toggle the visibility of its associated content.
+
+## Basic Usage
+
+Each accordion item requires a `title` attribute for the clickable header. The body content is placed inside the item tags.
+
+```blade
+<x-bladewind::accordion>
+    <x-bladewind::accordion.item title="What is BladewindUI?">
+        <p>
+            BladewindUI is a collection...
+        </p>
+    </x-bladewind::accordion.item>
+    <x-bladewind::accordion.item title="How can I install the latest version of the library?">
+        <div>
+            At the root of your Laravel...
+        </div>
+    </x-bladewind::accordion.item>
+    <x-bladewind::accordion.item title="How can I customize the library for my theme?">
+        <div>
+            BladewindUI has been designed ...
+        </div>
+    </x-bladewind::accordion.item>
+</x-bladewind::accordion>
+```
+
+## Custom Title Slot
+
+If the title of your accordion item is not a simple string, you can define your content in a title slot.
+
+```blade
+<x-bladewind::accordion>
+    <x-bladewind::accordion.item>
+        <x-slot:title>
+            <div class="inline-flex">
+                <div><img src="/assets/images/icon.png" class="size-10..." alt="logo"/></div>
+                <div class="ml-2">
+                    <div>What is BladewindUI library?</div>
+                    <div class="text-sm ...">version 2.8.0</div>
+                </div>
+            </div>
+        </x-slot:title>
+        <p>
+            BladewindUI is a collection...
+        </p>
+    </x-bladewind::accordion.item>
+    ...
+</x-bladewind::accordion>
+```
+
+## Open Multiple Accordion Items
+
+By default only one accordion can stay open at any point in time. You can disable this feature by setting `can_open_multiple="true"`. Now any closed accordion that is clicked will be opened. Likewise, any accordion that is open will be closed when clicked.
+
+```blade
+<x-bladewind::accordion
+    can_open_multiple="true">
+    <x-bladewind::accordion.item title="What is BladewindUI?">
+        <p>
+            BladewindUI is a collection...
+        </p>
+    </x-bladewind::accordion.item>
+    <x-bladewind::accordion.item title="How can I install the latest version of the library?">
+        <div>
+            At the root of your Laravel...
+        </div>
+    </x-bladewind::accordion.item>
+    <x-bladewind::accordion.item title="How can I customize the library for my theme?">
+        <div>
+            BladewindUI has been designed ...
+        </div>
+    </x-bladewind::accordion.item>
+</x-bladewind::accordion>
+```
+
+## Ungrouped Accordions
+
+The examples above showed the accordion items within one card element, each separated by a line. To separate accordion items so they stand alone, set `grouped="false"`.
+
+```blade
+<x-bladewind::accordion
+    grouped="false">
+    <x-bladewind::accordion.item title="What is BladewindUI?">
+        <p>
+            BladewindUI is a collection...
+        </p>
+    </x-bladewind::accordion.item>
+    <x-bladewind::accordion.item title="How can I install the latest version of the library?">
+        <div>
+            At the root of your Laravel...
+        </div>
+    </x-bladewind::accordion.item>
+    <x-bladewind::accordion.item title="How can I customize the library for my theme?">
+        <div>
+            BladewindUI has been designed ...
+        </div>
+    </x-bladewind::accordion.item>
+</x-bladewind::accordion>
+```
+
+## Colourful Accordions
+
+You can define the background colour of the accordion by setting the `color` attribute. This is only enforced if `grouped="false"`. Available colours include: `primary`, `blue`, `red`, `yellow`, `green`, `purple`, `pink`, `orange`, `black`, `cyan`, `violet`, `indigo`, `fuchsia`.
+
+```blade
+<x-bladewind::accordion
+    grouped="false"
+    color="yellow">
+    <x-bladewind::accordion.item title="What is BladewindUI?">
+        <p>
+            BladewindUI is a collection...
+        </p>
+    </x-bladewind::accordion.item>
+...
+</x-bladewind::accordion>
+```
+
+## Attributes
+
+### Accordion Component
+
+| Attribute | Default | Description |
+|---|---|---|
+| grouped | true | Should the accordion items be grouped within one card container. If `true`, the accordions are divided by lines and grouped in one big container. `true` \| `false` |
+| can_open_multiple | false | Should the accordion allow opening of items without first closing what is open. `true` \| `false` |
+| color | _blank_ | The accordion background. Applicable when `grouped="false"`. `primary` \| `blue` \| `red` \| `yellow` \| `green` \| `purple` \| `pink` \| `orange` \| `black` \| `cyan` \| `violet` \| `indigo` \| `fuchsia` |
+| no_padding | false | Specifies if there should be air around the accordion group. `true` \| `false` |
+| content_can_close | true | Determines if clicking on the accordion content will close it when it is open. `true` \| `false` |
+| class | _blank_ | Any additional css classes can be added using this attribute. For example to make your accordion more rounded you can add `class="rounded-2xl"`. |
+
+### Accordion Item Component
+
+| Attribute | Default | Description |
+|---|---|---|
+| open | false | Should the accordion items be opened or closed by default. `true` \| `false` |
+| title | _blank_ | Label to display as the title of the accordion. |
+| color | _blank_ | The accordion background. Applicable when `grouped="false"`. `primary` \| `blue` \| `red` \| `yellow` \| `green` \| `purple` \| `pink` \| `orange` \| `black` \| `cyan` \| `violet` \| `indigo` \| `fuchsia` |
+| class | _blank_ | Any additional css classes can be added using this attribute. |
+| no_padding | false | Specifies if there should be air around each accordion item. `true` \| `false` |
+| content_can_close | true | Determines if clicking on the accordion content will close it when it is open. `true` \| `false` |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. |
+
+## Full Example
+
+```blade
+<x-bladewind::accordion
+    grouped="false"
+    can_open_multiple="false"
+    color="pink"
+    class="rounded-lg shadow-sm">
+...
+</x-bladewind::accordion>
+```
+
+```blade
+<x-bladewind::accordion.item
+    color="blue"
+    open="false"
+    title="What is BladewindUI?"
+    class="shadow">
+...
+</x-bladewind::accordion.item>
+```

--- a/mcp/alert.md
+++ b/mcp/alert.md
@@ -1,0 +1,162 @@
+---
+title: Alert Component
+component: x-bladewind::alert
+url: /component/alert
+---
+
+# Alert
+
+The alert component displays inline messages intended to get the attention of your users. Alerts come in two shade variants — `faint` (default) and `dark` — and four prebuilt types: `info`, `error`, `warning`, and `success`. Each prebuilt type has a default icon. Custom colours, icons, and avatars are also supported.
+
+For floating/overlay alerts, see the [Notification](/component/notification) component instead.
+
+## Basic Usage
+
+```blade
+<x-bladewind::alert>
+    Your subscription is expiring in 19 days. <a href="#">Renew now</a>
+</x-bladewind::alert>
+
+<x-bladewind::alert type="error">
+    You do not have permission to upload files
+</x-bladewind::alert>
+
+<x-bladewind::alert type="warning">
+    Well, this is your first warning.
+</x-bladewind::alert>
+
+<x-bladewind::alert type="success">
+    Files were successfully uploaded
+</x-bladewind::alert>
+```
+
+## Shades
+
+Set `shade="dark"` for a darker background variant.
+
+```blade
+<x-bladewind::alert shade="dark">
+    Your subscription is expiring in 19 days.
+</x-bladewind::alert>
+
+<x-bladewind::alert type="error" shade="dark">
+    You do not have permission to upload files
+</x-bladewind::alert>
+```
+
+## Hiding Icons
+
+By default, alerts show both a type icon and a close icon. Both can be hidden independently.
+
+```blade
+{{-- hide the close icon only --}}
+<x-bladewind::alert show_close_icon="false">
+    Message here
+</x-bladewind::alert>
+
+{{-- hide the type icon only --}}
+<x-bladewind::alert show_icon="false">
+    Message here
+</x-bladewind::alert>
+
+{{-- hide both icons --}}
+<x-bladewind::alert show_icon="false" show_close_icon="false">
+    Message here
+</x-bladewind::alert>
+```
+
+## Custom Colours
+
+All BladewindUI palette colours are supported on both `faint` and `dark` shades.
+
+```blade
+<x-bladewind::alert color="pink">I am a pink alert.</x-bladewind::alert>
+<x-bladewind::alert color="pink" shade="dark">I am a pink alert. Dark version.</x-bladewind::alert>
+<x-bladewind::alert color="cyan">I am a cyan alert.</x-bladewind::alert>
+<x-bladewind::alert color="purple">I am a purple alert.</x-bladewind::alert>
+<x-bladewind::alert color="orange">I am an orange alert.</x-bladewind::alert>
+<x-bladewind::alert color="violet">I am a violet alert.</x-bladewind::alert>
+<x-bladewind::alert color="indigo">I am an indigo alert.</x-bladewind::alert>
+<x-bladewind::alert color="fuchsia">I am a fuchsia alert.</x-bladewind::alert>
+<x-bladewind::alert color="gray">I am a gray alert.</x-bladewind::alert>
+<x-bladewind::alert color="transparent">I am a transparent alert.</x-bladewind::alert>
+```
+
+## Custom Icons
+
+The four prebuilt alert types have their own icons. For other colours or types, set the `icon` attribute to any [Heroicons](https://heroicons.com) name.
+
+```blade
+<x-bladewind::alert color="indigo" icon="bell-alert">
+    No more alarm snoozing. Wake up!
+</x-bladewind::alert>
+
+<x-bladewind::alert color="indigo" shade="dark" icon="currency-dollar">
+    Your BladewindUI subscription is expiring soon. Pay up!
+</x-bladewind::alert>
+```
+
+To adjust the icon size, use `icon_avatar_css` with TailwindCSS classes.
+
+```blade
+<x-bladewind::alert color="cyan" shade="dark" icon="currency-dollar"
+    icon_avatar_css="!h-16 !w-16 opacity-60">
+    <div><strong>Subscription overdue</strong></div>
+    Your BladewindUI subscription is overdue by 3 months.
+</x-bladewind::alert>
+```
+
+## Avatars
+
+Use an image as a prefix instead of an icon by setting the `avatar` attribute to an image URL. Avatars are rendered using the [Avatar](/component/avatar) component.
+
+```blade
+<x-bladewind::alert color="violet" shade="dark" avatar="/images/jane.jpg">
+    Jane has been added to your friends list
+</x-bladewind::alert>
+
+{{-- with a ring and larger size --}}
+<x-bladewind::alert color="cyan" shade="dark"
+    avatar="/images/jane.jpg"
+    size="regular"
+    show_ring="true">
+    <div><strong>New friend request</strong></div>
+    Jane C. Doe wants to connect as a friend in your professional network.
+    <div class="text-sm opacity-70">2 days ago</div>
+</x-bladewind::alert>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| type | info | `info` \| `error` \| `warning` \| `success` |
+| shade | faint | `faint` \| `dark` |
+| color | _(blank)_ | Override colour: `primary` `blue` `red` `yellow` `green` `purple` `pink` `orange` `black` `cyan` `violet` `indigo` `fuchsia` `gray` `transparent` |
+| show_close_icon | true | Show the dismiss (×) icon. String, not boolean. `true` \| `false` |
+| show_icon | true | Show the type icon. String, not boolean. `true` \| `false` |
+| icon | _(blank)_ | Any [Heroicons](https://heroicons.com) icon name |
+| avatar | _(blank)_ | URL to an image to display as a prefix |
+| icon_avatar_css | _(blank)_ | Additional TailwindCSS classes for the icon or avatar |
+| size | tiny | Avatar size (inherits from Avatar component): `tiny` `small` `regular` `medium` `big` |
+| show_ring | false | Show a ring around the avatar. `true` \| `false` |
+| class | _(blank)_ | Additional CSS classes applied to the alert wrapper |
+
+## Full Example
+
+```blade
+<x-bladewind::alert
+    type="warning"
+    shade="dark"
+    show_close_icon="false"
+    show_icon="false"
+    color="pink"
+    icon="briefcase"
+    icon_avatar_css="bg-slate-800"
+    show_ring="true"
+    avatar="/assets/images/me.jpg"
+    size="small"
+    class="rounded-lg shadow-sm">
+    Stay safe. Wash your hands for 20 seconds
+</x-bladewind::alert>
+```

--- a/mcp/avatar.md
+++ b/mcp/avatar.md
@@ -1,0 +1,205 @@
+---
+title: Avatar Component
+component: x-bladewind::avatar
+url: /component/avatar
+---
+
+# Avatar
+
+The avatar component allows you to display a rounded picture at different sizes. This component can be useful for displaying pictures of logged-in users, a contact list, directory of employees, etc. The avatar component can either display a single image or a horizontal stack of images. A default placeholder image is used when the `image` attribute is either blank or not specified.
+
+## Single Avatar
+
+```blade
+<x-bladewind::avatar image="/path/to/the/image/file" />
+```
+
+## Different Sizes
+
+You can specify a size for the avatar. The default size is `regular`.
+
+```blade
+<x-bladewind::avatar
+    image="/path/to/the/image/file"
+    size="tiny" />
+
+<x-bladewind::avatar
+    image="/path/to/the/image/file"
+    size="small" />
+
+<x-bladewind::avatar
+    image="/path/to/the/image/file"
+    size="medium" />
+
+// this is the default
+<x-bladewind::avatar
+    image="/path/to/the/image/file" />
+
+<x-bladewind::avatar
+    image="/path/to/the/image/file"
+    size="big" />
+
+<x-bladewind::avatar
+    image="/path/to/the/image/file"
+    size="huge" />
+
+<x-bladewind::avatar
+    image="/path/to/the/image/file"
+    size="omg" />
+```
+
+## Stacked Avatars
+
+Stacked avatars are a series of avatars overlapping each other. The component will not restrict you from stacking avatars of different sizes but, for a more appealing visual effect, stacking images of the same size is advised. You can achieve 'stackability' by using the `x-bladewind::avatars` component and setting `stacked="true"`.
+
+```blade
+<x-bladewind::avatars stacked="true">
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+</x-bladewind::avatars>
+```
+
+### Plus More
+
+There are cases where you have several avatars but only want to display a specific number and indicate how many more there are. You can achieve this by setting the `plus` attribute to any positive whole number. Setting the `plus` attribute automatically sets `stacked="true"`. BladewindUI also allows you to specify an action for your "plus more" avatar by specifying the `plus_action` attribute. This accepts a Javascript function.
+
+```blade
+<x-bladewind::avatars
+    plus="95"
+    plus_action="alert('show more avatars')">
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+    <x-bladewind::avatar image="/path/to/the/image/file" />
+</x-bladewind::avatars>
+```
+
+## Dot Indicator
+
+Avatars can be displayed with a status indicator. These statuses could be online, offline, invisible. To show a dot indicator on an avatar simply set `dotted="true"`.
+
+```blade
+<x-bladewind::avatar
+    dotted="true"
+    image="/path/to/the/image/file" />
+```
+
+By default the dot indicator is displayed at the base of the avatar. To change the position to the top of the avatar, set the `dot_position="top"` attribute.
+
+```blade
+<x-bladewind::avatar
+    dotted="true"
+    dot_position="top"
+    image="/path/to/the/image/file" />
+```
+
+The dot is available in different colours. Set the `dot_color` attribute to any of the colours compiled into BladewindUI.
+
+```blade
+<x-bladewind::avatars dotted="true">
+    <x-bladewind::avatar dot_color="primary" image="..." />
+    <x-bladewind::avatar dot_color="gray" image="..." />
+    <x-bladewind::avatar dot_color="red" image="..." />
+</x-bladewind::avatars>
+```
+
+## Labels
+
+You may have seen on websites where the initials of your name are displayed if you have not set a profile image. You can achieve this by specifying a value for the `label` attribute. A label is also displayed when the `image` specified is three or less characters long.
+
+```blade
+<x-bladewind::avatar dotted="true" label="MO" />
+```
+
+```blade
+<x-bladewind::avatar label="MK" />
+```
+
+```blade
+<x-bladewind::avatar image="PP" />
+```
+
+Stacked avatars with labels and dot indicators:
+
+```blade
+<x-bladewind::avatars stacked="true" dotted="true" plus="34">
+    <x-bladewind::avatar label="SF" />
+    <x-bladewind::avatar label="ZH" />
+    <x-bladewind::avatar label="RB" />
+</x-bladewind::avatars>
+```
+
+Avatars with custom background and dot colours:
+
+```blade
+<x-bladewind::avatars dotted="true" class="space-x-4">
+    <x-bladewind::avatar label="SF" bg_color="orange" dot_color="orange" />
+    <x-bladewind::avatar label="ZH" bg_color="blue" dot_color="blue" />
+    <x-bladewind::avatar label="RB" bg_color="purple" dot_color="purple" />
+</x-bladewind::avatars>
+```
+
+## Attributes
+
+### Avatars Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| size | regular | Specifies the size of all the avatars in the group. `tiny` \| `small` \| `medium` \| `regular` \| `big` \| `huge` \| `omg` |
+| stacked | false | Specifies if the avatars are displayed as a stack. `true` \| `false` |
+| dotted | false | Specifies if the avatars have dot indicators. `true` \| `false` |
+| dot_color | green | Specifies what colour to use as the dot indicator. Only relevant if _dotted=true_. `primary` \| `blue` \| `red` \| `yellow` \| `green` \| `purple` \| `pink` \| `orange` \| `gray` \| `cyan` |
+| dot_position | bottom | Specifies where the dot indicator should be placed. Only relevant if _dotted=true_. `top` \| `bottom` |
+| show_ring | true | By default avatars show a ring around them. Setting this can turn it off or back on. `true` \| `false` |
+| plus | null | Display a last avatar with +XX in the box indicating how many more avatars there are. Must be a positive integer greater than zero. |
+| plus_action | null | The Javascript action to perform when the +XX avatar is clicked. |
+| bg_color | null | Display background colour when displaying avatars as labels. This sets the ring colour too. `primary` \| `blue` \| `red` \| `yellow` \| `green` \| `purple` \| `pink` \| `orange` \| `black` \| `cyan` \| `violet` \| `indigo` \| `fuchsia` |
+| class | mr-2 mt-2 | Any additional css classes can be added using this attribute. This only affects the avatars container. |
+
+### Avatar Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| image | _public/vendor/bladewind/images/avatar.png_ | The url to the image file. By default a generic headshot image is used if no url is passed. The image will be displayed as a label if it is three characters long or less. |
+| alt | image | The text to display as the value for the image's alt attribute. |
+| size | regular | Specifies the size of the avatar. `tiny` \| `small` \| `medium` \| `regular` \| `big` \| `huge` \| `omg` |
+| stacked | false | Specifies if the avatar images are displayed as a stack. `true` \| `false` |
+| dotted | false | Specifies if the avatar images have dot indicators. `true` \| `false` |
+| dot_color | green | Specifies what colour to use as the dot indicator. Only relevant if _dotted=true_. `primary` \| `blue` \| `red` \| `yellow` \| `green` \| `purple` \| `pink` \| `orange` \| `gray` \| `cyan` |
+| dot_position | bottom | Specifies where the dot indicator should be placed. Only relevant if _dotted=true_. `top` \| `bottom` |
+| label | null | Text to display in place of an image. Usually two characters. |
+| show_ring | true | By default avatars show a ring around them. Setting this can turn it off or back on. `true` \| `false` |
+| class | mr-2 mt-2 | Any additional css classes can be added using this attribute. |
+
+## Full Example
+
+```blade
+<x-bladewind::avatars
+    size="big"
+    show_ring="false"
+    dotted="true"
+    dot_color="red"
+    dot_position="top"
+    plus="33"
+    plus_action="showMorePictures()"
+    stacked="true"
+    class="ring-blue-200 ring-offset-2" />
+```
+
+```blade
+<x-bladewind::avatar
+    image="/path/to/the/image/file"
+    alt="company logo"
+    size="big"
+    stacked="true"
+    dotted="true"
+    bg_color="cyan"
+    show_ring="false",
+    dot_color="red",
+    dot_position="top"
+    class="ring-blue-200 ring-offset-2" />
+```

--- a/mcp/bell.md
+++ b/mcp/bell.md
@@ -1,0 +1,151 @@
+---
+title: Bell Component
+component: x-bladewind::bell
+url: /component/bell
+---
+
+# Bell
+
+The bell component displays a bell icon with an optional 'pending notifications' dot indicator. This is a visually pleasing way of telling your app users where to find notifications and if they have anything unread. By default, the bell displays the dot indicator, meaning there are notifications to be read.
+
+```blade
+<x-bladewind::bell />
+```
+
+### No Dot Indicator
+
+To display the bell with no dot indicator, set `show_dot="false"`. This hides the dot indicator. This should usually be the case if all notifications have been read.
+
+```blade
+<x-bladewind::bell show_dot="false" />
+```
+
+### Animated Dot Indicator
+
+The dot indicator can have a 'ping' animation to draw attention to the bell. To animate the dot set `animate_dot="true"`. By default, the dot is not animated.
+
+```blade
+<x-bladewind::bell animate_dot="true" />
+```
+
+### Inverted Bell
+
+By default, the bell is designed to sit on a white background. When using the bell on a dark background, set the attribute `invert="true"`. This will display the bell as white.
+
+```blade
+<x-bladewind::bell invert="true" />
+```
+
+## Different Sizes
+
+The bell component exists in two sizes: `small` and `big`. The default size is `small`.
+
+```blade
+// size="small" can be omitted since it is the default
+<x-bladewind::bell size="small" />
+```
+
+```blade
+<x-bladewind::bell size="big" />
+```
+
+## Different Colours
+
+The default dot indicator displayed next to the bell is blue. This may not match your app's theme, so it is possible to display the dot indicator in different colours by setting the `color` attribute.
+
+```blade
+<x-bladewind::bell color="primary" />
+
+<x-bladewind::bell color="red" />
+
+<x-bladewind::bell color="yellow" />
+
+<x-bladewind::bell color="green" />
+
+<x-bladewind::bell color="pink" />
+
+<x-bladewind::bell color="cyan" />
+
+<x-bladewind::bell color="black" />
+
+<x-bladewind::bell color="purple" />
+
+<x-bladewind::bell color="orange" />
+
+<x-bladewind::bell color="violet" />
+
+<x-bladewind::bell color="indigo" />
+
+<x-bladewind::bell color="fuchsia" />
+```
+
+## Events
+
+In most apps the bell is accessed either using onclick or onmouseover events. You can add these events to the component as you normally would to any tag. Alternatively, you could wrap the bell component in any other HTML tag that accepts click and hover events.
+
+The example below wraps the Bell component in the [Dropmenu](/component/dropmenu) component. The Dropmenu component then uses the [List View](/component/listmenu) component to display a list of notifications.
+
+```blade
+<x-bladewind::dropmenu>
+    <x-slot name="trigger">
+        <x-bladewind::bell />
+    </x-slot>
+    <x-bladewind.dropmenu.item>
+        <x-bladewind.listview transparent="true">
+
+            <x-bladewind.listview.item>
+                <x-bladewind.avatar size="small" image="..." />
+                <div class="mx-1 pt-1">
+                    <div class="text-sm">
+                        <span class="font-medium text-slate-900">
+                            Michael
+                        </span>
+                        assigned <a href="#">a task</a> to you
+                        <div class="text-xs">3 hours ago</div>
+                    </div>
+                </div>
+            </x-bladewind.listview.item>
+
+            <x-bladewind.listview.item>
+                ...
+            </x-bladewind.listview.item>
+
+        </x-bladewind.listview>
+    </x-bladewind.dropmenu.item>
+</x-bladewind.dropmenu>
+```
+
+### Onclick, Onmouseover, On-anything
+
+As seen in the example above, the Bell component inherits the default action defined in the Dropmenu component. If you prefer to design your own notification layout or redirect users to a page that lists their notifications, you can define any HTML event attribute on the Bell.
+
+```blade
+<x-bladewind::bell
+    onmouseover="alert('..')" />
+```
+
+```blade
+<x-bladewind::bell
+    onclick="alert('...')" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| color | _blue_ | The colour of the dot indicator. `primary` \| `blue` \| `red` \| `yellow` \| `green` \| `pink` \| `cyan` \| `black` \| `purple` \| `orange` \| `violet` \| `indigo` \| `fuchsia` |
+| animate_dot | false | Determines if the dot should be animated or not. |
+| size | small | Defines the size of the bell. `small` \| `big` |
+| show_dot | true | Defines if the dot indicator should be displayed by default. `true` \| `false` |
+| invert | false | Defines if the bell should be displayed as white. `true` \| `false` |
+
+## Full Example
+
+```blade
+<x-bladewind::bell
+    color="pink"
+    show_dot="false"
+    animate_dot="true"
+    invert="true"
+    size="big" />
+```

--- a/mcp/button.md
+++ b/mcp/button.md
@@ -1,0 +1,205 @@
+---
+title: Button Component
+component: x-bladewind::button
+url: /component/button
+---
+
+# Button
+
+The button component renders as an HTML `<button>` tag by default. Primary and secondary colours are derived from what you define as `primary` and `secondary` in your `tailwind.config.js`. Buttons come in four types: primary, secondary, circular, and outline. All types support multiple sizes, colours, icons, and spinners.
+
+## Basic Usage
+
+```blade
+<x-bladewind::button>Subscribe Now</x-bladewind::button>
+
+{{-- preserve casing --}}
+<x-bladewind::button uppercasing="false">Subscribe Now</x-bladewind::button>
+
+{{-- render as an <a> tag --}}
+<x-bladewind::button tag="a" href="/pricing">Subscribe Now</x-bladewind::button>
+```
+
+## Button Types
+
+### Primary
+
+```blade
+<x-bladewind::button>Primary Button</x-bladewind::button>
+<x-bladewind::button outline="true">Primary Outline</x-bladewind::button>
+```
+
+### Secondary
+
+```blade
+<x-bladewind::button type="secondary">Secondary Button</x-bladewind::button>
+<x-bladewind::button type="secondary" outline="true">Secondary Outline</x-bladewind::button>
+```
+
+### Circular
+
+Circular buttons accept icons only.
+
+```blade
+<x-bladewind::button.circle icon="bell-alert" />
+<x-bladewind::button.circle outline="true" icon="bell-alert" />
+
+{{-- secondary circular (use color instead of type) --}}
+<x-bladewind::button.circle color="secondary" outline icon="bell-alert" />
+```
+
+### Outline
+
+Set `outline="true"` on any button to strip the background and keep only the border.
+
+```blade
+<x-bladewind::button outline="true" color="cyan" radius="full">Cyan Outline</x-bladewind::button>
+<x-bladewind::button type="secondary" outline="true" radius="full">Secondary Outline</x-bladewind::button>
+
+{{-- custom border width (default is 2) --}}
+<x-bladewind::button outline="true" border_width="4">Border 4</x-bladewind::button>
+<x-bladewind::button outline="true" border_width="8">Border 8</x-bladewind::button>
+```
+
+## Sizes
+
+Available sizes: `tiny`, `small`, `regular` (default), `medium`, `big`. Sizes apply to both regular and circular buttons.
+
+```blade
+<x-bladewind::button size="tiny">Tiny</x-bladewind::button>
+<x-bladewind::button size="small">Small</x-bladewind::button>
+<x-bladewind::button>Regular (default)</x-bladewind::button>
+<x-bladewind::button size="medium">Medium</x-bladewind::button>
+<x-bladewind::button size="big">Big</x-bladewind::button>
+```
+
+## Radii
+
+```blade
+<x-bladewind::button radius="none">None</x-bladewind::button>
+<x-bladewind::button radius="small">Small</x-bladewind::button>
+<x-bladewind::button radius="medium">Medium</x-bladewind::button>
+<x-bladewind::button radius="full">Full</x-bladewind::button>
+```
+
+## Disabled
+
+```blade
+<x-bladewind::button disabled="true">Disabled</x-bladewind::button>
+<x-bladewind::button disabled="true" type="secondary">Disabled Secondary</x-bladewind::button>
+<x-bladewind::button disabled="true" outline>Disabled Outline</x-bladewind::button>
+```
+
+## Focus Rings
+
+```blade
+{{-- hide focus ring --}}
+<x-bladewind::button show_focus_ring="false">No Focus Ring</x-bladewind::button>
+
+{{-- custom ring width --}}
+<x-bladewind::button ring_width="1">Ring 1</x-bladewind::button>
+<x-bladewind::button ring_width="4">Ring 4</x-bladewind::button>
+```
+
+## Spinners
+
+Set `has_spinner="true"` to include a spinner (hidden by default). Use `show_spinner="true"` to make it visible on load. To trigger the spinner on click, set a `name` and call `showButtonSpinner()` in `onclick`.
+
+```blade
+{{-- spinner visible by default --}}
+<x-bladewind::button has_spinner="true" show_spinner="true">Saving...</x-bladewind::button>
+
+{{-- spinner triggered on click --}}
+<x-bladewind::button
+    has_spinner="true"
+    name="save-user"
+    onclick="showButtonSpinner('.save-user')">
+    Save User
+</x-bladewind::button>
+```
+
+## Icons
+
+Set `icon` to any [Heroicons](https://heroicons.com) name. Icons default to the left; use `icon_right="true"` to move them right. Note: `icon_right` is ignored when `has_spinner="true"`.
+
+```blade
+<x-bladewind::button icon="arrow-path">Refresh Page</x-bladewind::button>
+<x-bladewind::button icon="arrow-path" icon_right="true">Refresh Page</x-bladewind::button>
+
+<x-bladewind::button type="secondary" icon="arrow-small-right" icon_right="true">
+    Next Chapter
+</x-bladewind::button>
+```
+
+## Form Submission
+
+By default the button renders as `<button type="button">` and will not submit forms. Set `can_submit="true"` to render as `<button type="submit">`.
+
+```blade
+<x-bladewind::button can_submit="true">Submit Form</x-bladewind::button>
+```
+
+## Custom Colours
+
+Only primary buttons support custom colours. Useful when you need a colour that differs from your project's primary (e.g. red delete buttons).
+
+```blade
+<x-bladewind::button color="red">Red Button</x-bladewind::button>
+<x-bladewind::button color="red" outline>Red Outline</x-bladewind::button>
+```
+
+Available colours: `primary` `blue` `red` `yellow` `green` `purple` `pink` `orange` `black` `cyan` `violet` `indigo` `fuchsia` `gray`
+
+## Button Events
+
+Any HTML button event attribute can be passed directly to the component.
+
+```blade
+<x-bladewind::button onclick="alert('you clicked me')">Click Me</x-bladewind::button>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| type | primary | `primary` \| `secondary` |
+| size | regular | `tiny` \| `small` \| `regular` \| `medium` \| `big` |
+| name | _(blank)_ | Added to the button's `class` for JS/CSS targeting |
+| color | primary | Button colour. See available colours above |
+| outline | false | Show as outline only (no background). `true` \| `false` |
+| border_width | 2 | Outline border width. `2` \| `4` \| `8` |
+| radius | full | `none` \| `small` \| `medium` \| `full` |
+| disabled | false | Disable the button. `true` \| `false` |
+| tag | button | HTML tag to use. `button` \| `a` |
+| can_submit | false | Render as `type="submit"`. `true` \| `false` |
+| has_spinner | false | Include a spinner. `true` \| `false` |
+| show_spinner | false | Show spinner on load. Only when `has_spinner="true"`. `true` \| `false` |
+| icon | _(blank)_ | Any Heroicons icon name |
+| icon_right | false | Position icon to the right. Ignored when `has_spinner="true"`. `true` \| `false` |
+| show_focus_ring | true | Show focus ring. `true` \| `false` |
+| ring_width | _(blank)_ | Focus ring width: `1` \| `2` \| `4` \| `8` |
+| uppercasing | true | Uppercase button text. `true` \| `false` |
+| button_text_css | _(blank)_ | TailwindCSS classes to override button text colour |
+
+## Full Example
+
+```blade
+<x-bladewind::button
+    type="secondary"
+    size="big"
+    name="btn-subscribe"
+    has_spinner="true"
+    show_spinner="false"
+    disabled="false"
+    tag="a"
+    outline="true"
+    border_width="2"
+    show_focus_ring="false"
+    radius="medium"
+    icon="lock-closed"
+    icon_right="false"
+    button_text_css="font-bold text-black"
+    can_submit="false">
+    Subscribe
+</x-bladewind::button>
+```

--- a/mcp/calendar.md
+++ b/mcp/calendar.md
@@ -1,0 +1,172 @@
+---
+title: Datepicker Component
+component: x-bladewind::datepicker
+url: /component/calendar
+---
+
+# Datepicker
+
+Display a calendar so user can select a date. The calendar component is locale friendly. Months and days are translated.
+
+> **This component requires the AlpineJS library to work.** Ensure you include the script below if you don't have AlpineJS already in your project.
+
+```blade
+<script src="//unpkg.com/alpinejs" defer></script>
+```
+
+```blade
+<x-bladewind::datepicker  />
+```
+
+By default the datepicker fills up the width of its parent container. You can however specify a width of your choice using a wrapper element with a width class.
+
+You can also change the placeholder text from the default `Select a date`.
+
+```blade
+<div class="w-40">
+    <x-bladewind::datepicker placeholder="Invoice Date"  />
+</div>
+```
+
+## Range Datepicker
+
+This range datepicker isn't your typical date range selection you will find on airline websites. This option simply saves you from manually embedding the datepicker two times. Specifying `type="range"` will create two separate datepicker boxes for start and end dates.
+
+```blade
+<x-bladewind::datepicker type="range"  />
+```
+
+The default placeholder texts for the range datepicker are **From** and **To**. These can however, be modified using the `date_from_label` and `date_to_label` attributes. These attributes only work if `type="range"`. Also, we introduced `stacked="true"` to stack the datepickers vertically.
+
+```blade
+<x-bladewind::datepicker
+    type="range"
+    date_from_label="start date"
+    date_to_label="end date" />
+```
+
+### Show As a Required Field
+
+An asterisk is appended to the placeholder text when `required="true"`.
+
+```blade
+<x-bladewind::datepicker required="true"  />
+```
+
+### Validating The Range Picker
+
+The date range picker comes with optional date validation. This validation only checks to ensure the end date is not less than the start date. To enforce validation of the date range picker, set `validate="true"`. This is only applied if `type="range"`.
+
+When you activate validation, you will need to provide the message to be displayed when a user selects an end date that is less than the start date. This is provided as an option to make it translatable. Set `validation_message="your message here"`.
+
+```blade
+<x-bladewind::datepicker
+    type="range"
+    date_from_label="task starts"
+    date_to_label="task due"
+    validate="true"
+    validation_message="Seriously!, you know your task cannot end before you even got started"  />
+```
+
+By default, the error validation message is displayed in the BladewindUI notification component. You will need to ensure you have the `x-bladewind.notification` component on your page for the error message to be visible. If you prefer to display the error message inline, under the date fields, simply set `show_error_inline="true"`.
+
+## Date Formats
+
+You can specify how you want dates selected in the datepicker to be displayed. There are four options to pick from. The default format is `format="yyyy-mm-dd"`. When using a range datepicker, the format you specify is applied to both datepickers.
+
+```blade
+<x-bladewind::datepicker name="date1" type="range" format="dd-mm-yyyy" />
+```
+
+```blade
+<x-bladewind::datepicker name="date2" format="mm-dd-yyyy" />
+```
+
+```blade
+<x-bladewind::datepicker name="date3" format="D d M, Y" type="range" />
+```
+
+```blade
+<x-bladewind::datepicker name="date4" format="yyyy-mm-dd" />
+```
+
+## With Default Values
+
+There are times you will want the datepicker to load prepopulated with a default value. This is useful when in edit mode or when using filters and you want to show the user what dates they filtered by.
+
+```blade
+<x-bladewind::datepicker default_date="2021-12-03"  />
+```
+
+It is possible to have default dates for a range datepicker also.
+
+```blade
+<x-bladewind::datepicker
+    type="range"
+    default_date_from="2021-12-03"
+    default_date_to="2022-01-03"  />
+```
+
+## Min and Max Dates
+
+Setting minimum and maximum dates restrict the datepicker to display dates only within these specified dates. The `min_date` attribute allows you to set the accepted minimum date. Any dates before this date will be disabled and grayed out. The `max_date` attribute allows you to set the accepted maximum date. Any dates after this date will be disabled and grayed out.
+
+```blade
+<x-bladewind::datepicker min_date="{{date('Y-m-d')}}" />
+```
+
+```blade
+<x-bladewind::datepicker max_date="{{date('Y-m-t')}}" />
+```
+
+```blade
+<x-bladewind::datepicker min_date="{{date('Y-m-01')}}" max_date="{{date('Y-m-t')}}" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | bw-datepicker | This name can be accessed when the input is submitted in the form. The name is also available as part of the css classes. |
+| type | single | `single` \| `range` |
+| default_date | _blank_ | In case you are editing a form, the value passed will be set on the value attribute of the datepicker input. |
+| default_date_from | _blank_ | Default date to set for the _From_ date when using the range datepicker. |
+| default_date_to | _blank_ | Default date to set for the _To_ date when using the range datepicker. |
+| min_date | _blank_ | Restrict the date to start from this. Any dates before this will be disabled and grayed out. |
+| max_date | _blank_ | Restrict the date to end at this. Any dates after this will be disabled and grayed out. |
+| date_from_label | From | Placeholder text to display for the `From` date. Applicable only to range datepickers. |
+| date_to_label | To | Placeholder text to display for the `To` date. Applicable only to range datepickers. |
+| format | yyyy-mm-dd | How date should be formatted. `yyyy-mm-dd` \| `dd-mm-yyyy` \| `mm-dd-yyyy` \| `D d M, Y` |
+| placeholder | Select a date | Placeholder text to display. |
+| required | false | Determines if the placeholder text should have an asterisk appended to it or not. `true` \| `false` |
+| onblur | _blank_ | Custom function to call when the datepicker loses focus. |
+| week_starts | sun | Choose between Sunday and Monday as the first day of the week. `sun` \| `mon` |
+| class | bw-datepicker | Any additional css classes can be added using this attribute. |
+| validate | false | Applied if `type="range"` to enforce if the start date should not be greater than the end date. `true` \| `false` |
+| validation_message | Your end date cannot be less than your start date | Applied if `type="range"`. Message to display if there is a validation error. |
+| show_error_inline | false | Applied if `type="range"` to specify how the error should be displayed. `true` \| `false` |
+| use_placeholder | true | Applied if `type="range"` to specify if the placeholder should be explicitly used instead of labels. `true` \| `false` |
+| stacked | true | Applied if `type="range"` to specify if the datepickers should be stacked vertically. `true` \| `false` |
+| size | medium | Sizing of the input to match button sizes. `tiny` \| `small` \| `regular` \| `big` |
+
+## Full Example
+
+```blade
+<x-bladewind::datepicker
+    name="invoice_date"
+    type="single"
+    required="false"
+    placeholder="Invoice Date"
+    date_from=""
+    date_to=""
+    default_date=""
+    has_label="true"
+    validate="false"
+    show_error_inline="true"
+    stacked="true"
+    use_placeholder="false"
+    validation_message="end date before start date! Really?"
+    onblur="copyDate('copy_from', 'copy_to')"
+    week_starts="mon"
+    class="shadow-sm" />
+```

--- a/mcp/card.md
+++ b/mcp/card.md
@@ -1,0 +1,276 @@
+---
+title: Card Component
+component: x-bladewind::card
+url: /component/card
+---
+
+# Card
+
+This component makes it easy to display content in a card layout. What you get by default is a very basic card. Considering different people have very different card needs, the content of the card is absolutely up to the user. There is provision for some very specific card use cases: you can specify if the card has a header and a footer. There are also contact cards which are very specific for displaying contact details.
+
+## Basic Card
+
+This just gives you the card frame with the option to define a heading text or card title.
+
+```blade
+<x-bladewind::card>
+    // the card content goes here
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind::card title="recent activity">
+    // the card content goes here
+</x-bladewind::card>
+```
+
+## Different Radii
+
+The card component comes with predefined radii which correspond to specific TailwindCSS classes for roundness. The default value is `small` which corresponds to Tailwind's `rounded-lg` class. To change the card's border radius, specify the `radius` attribute.
+
+```blade
+<x-bladewind::card radius="none">
+    // content
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind::card radius="small">
+    // content
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind::card radius="medium">
+    // content
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind::card radius="large">
+    // content
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind::card radius="xl">
+    // content
+</x-bladewind::card>
+```
+
+If you need to completely overwrite the radius of the card, you can specify any of the Tailwind classes used for roundness in the `class` attribute.
+
+## Practical Examples
+
+### Invoice Table
+
+Below is an example of an invoice table sitting in a basic BladewindUI Card.
+
+```blade
+<x-bladewind::card title="invoice details">
+
+    <x-bladewind.table striped="true">
+        <x-slot name="header">
+            <th>Item</th>
+            <th width="10%" class="text-center">Quantity</th>
+            <th width="20%" class="text-right">Price (USD)</th>
+        </x-slot>
+        <tr>
+            <td>Airpods Max (Black)</td>
+            <td class="text-center">1</td>
+            <td class="text-right">500.00</td>
+        </tr>
+        ...
+    </x-bladewind.table>
+
+</x-bladewind::card>
+```
+
+### Huge Navigation Items
+
+Below is an example of a grid-based navigation that uses cards for its menu items. The hover effect is achieved by adding additional TailwindCSS classes to the `class` attribute of the card.
+
+```blade
+<div class="grid grid-cols-3 gap-5">
+
+    <x-bladewind::card class="cursor-pointer hover:shadow-gray-300">
+        <svg ...>...</svg>
+        <span class="text-center ...">Projects</span>
+    </x-bladewind::card>
+
+    <x-bladewind::card class="cursor-pointer hover:shadow-gray-300">
+        <svg...>...</svg>
+        <span class="text-center ...">Tasks</span>
+    </x-bladewind::card>
+
+    <x-bladewind::card class="cursor-pointer hover:shadow-gray-300">
+        <svg...>...</svg>
+        <span class="text-center ...">Ideas</span>
+    </x-bladewind::card>
+
+</div>
+```
+
+### Contact List
+
+Below is an example of a contact list using the `compact` mode.
+
+```blade
+<div class="grid grid-cols-2 gap-3">
+
+    <x-bladewind::card compact="true">
+        <div class="flex items-center">
+            <div>
+                <x-bladewind.avatar image="/path/to/the/image/file" />
+            </div>
+            <div class="grow pl-2 pt-1">
+                <b>Michael K. Ocansey</b>
+                <div class="text-sm">Senior Developer</div>
+                <div class="text-sm">Tech Team</div>
+            </div>
+            <div>
+                <a href="">
+                    <svg>
+                        ...
+                    </svg>
+                </a>
+            </div>
+        </div>
+    </x-bladewind::card>
+
+    <x-bladewind::card compact="true">
+        ...
+    </x-bladewind::card>
+
+</div>
+```
+
+## Contact Card
+
+This card component is very specific to rendering contacts. It saves you from having to manually build a contact card. A default avatar is used if one is not provided.
+
+```blade
+<x-bladewind.contact-card
+    name="Michael K. Ocansey"
+    mobile="+233.123.456.789"
+    image="/path/to/the/image/file"
+    position="Senior Copywriter"
+    email="mike@bladewindui.com"
+    birthday="01-May-2000" />
+```
+
+Setting `centered="true"` reformats the contact card and vertically aligns and centers the content.
+
+## Header and Footer
+
+You can specify a header and footer for the card component. This is set up as a slot so there is really no restriction to what goes inside the header and footer. Headers and footers are independent so you don't need to explicitly specify both. When the `header` slot is set, the main body of the card loses all its padding so you will need to style the card body as you wish.
+
+```blade
+<x-bladewind::card>
+
+    <x-slot:header>
+        <div class="flex px-4 pt-2 pb-3">
+            <x-bladewind.avatar
+                size="small"
+                image="/path/to/the/image/file" />
+            <div class="pl-2">
+                <span class="block...">mkocansey</span>
+                <span class="block...">Greater Accra, Accra</span>
+            </div>
+        </div>
+    </x-slot:header>
+
+    <img src="/path/to/the/image/file" />
+
+    <x-slot:footer>
+        <div class="flex justify-between p-4">
+            <div class="flex space-x-4">
+                <x-bladewind.icon name="heart" class="h-8 w-8..." />
+                <x-bladewind.icon name="chat-bubble-oval-left-ellipsis" class="h-8 w-8..." />
+                <x-bladewind.icon name="arrow-uturn-left" class="h-8 w-8..." />
+            </div>
+            <div>
+                <svg> ... </svg>
+            </div>
+        </div>
+    </x-slot:footer>
+
+</x-bladewind::card>
+```
+
+## Attributes
+
+### Card Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| title | _blank_ | Any title provided will become the card heading. |
+| header | _blank_ | Once a header slot is defined, the card splits into two uneven horizontal parts. The content of the header slot will be displayed first. |
+| footer | _blank_ | Once a footer slot is defined, the content of the slot gets fixed to the base of the card as a footer. |
+| compact | false | This controls how much padding is in the card. Setting this to `true` will reduce the padding. Only works if header and footer are not set. `true` \| `false` |
+| no_padding | false | This completely removes the padding within the card. Content will touch the edges of the card. `true` \| `false` |
+| has_shadow | true | This controls if the card should have a shadow effect. `true` \| `false` |
+| has_hover | false | Displays an extra shadow on hover of the card. `true` \| `false` |
+| url | null | Url to visit when the card is clicked. A path like `"/some-url"` uses the Bladewind `redirect()` helper. A function call like `"performSomeAction(some_id)"` triggers `javascript:performSomeAction(some_id)`. A full URL like `"https://..."` uses `window.open()`. |
+| radius | small | Increases the roundness of the card. `none` \| `small` \| `medium` \| `large` \| `xl` |
+| class | bw-card | Any additional css classes can be added using this attribute. |
+
+### Contact Card Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | _blank_ | Name of the contact. |
+| department | _blank_ | Department of the contact. |
+| position | _blank_ | Designation or position of the contact. |
+| image | _bladewind/images/avatar.png_ | Picture of the contact. |
+| email | _blank_ | Email of the contact. |
+| birthday | _blank_ | Birthday of the contact. |
+| mobile | _blank_ | Mobile of the contact. |
+| has_shadow | true | This controls if the card should have a shadow effect. `true` \| `false` |
+| has_hover | false | Displays an extra shadow on hover of the card. `true` \| `false` |
+| centered | false | Displays contact card vertically. `true` \| `false` |
+| no_padding | false | This completely removes the padding within the card. `true` \| `false` |
+| url | null | Url to visit when the card is clicked. Same URL behavior as the Card component. |
+| class | bw-contact-card | Any additional css classes can be added using this attribute. |
+
+## Full Example
+
+```blade
+<x-bladewind::card
+    title="recent updates"
+    has_shadow="true"
+    has_hover="false"
+    compact="false"
+    no_padding="true"
+    radius="large"
+    url="/user"
+    class="!rounded-none">
+
+    <x-slot:header>...</x-slot:header>
+    <x-slot:footer>...</x-slot:footer>
+
+    ...
+
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind.contact-card
+    name="Michael K. Ocansey"
+    mobile="+233.123.456.789"
+    image="/path/to/the/image/file"
+    position="Senior Copywriter"
+    email="mike@bladewindui.com"
+    department="Tech"
+    birthday="01-May-2000"
+    has_hover="true"
+    centered="true"
+    no_padding="true"
+    url="viewUserDetails(id)"
+    class="!rounded-none">
+
+    // you can define additional content here
+    ...
+
+</x-bladewind.contact-card>
+```

--- a/mcp/centered-content.md
+++ b/mcp/centered-content.md
@@ -1,0 +1,46 @@
+---
+title: Centered Content Component
+component: x-bladewind::centered-content
+url: /component/centered-content
+---
+
+# Centered Content
+
+Center content within a container. This container could be any block level element, say a `div`.
+
+There are different sizes for the centered content component which are too wide for this documentation space. Try them out in your layouts to see how they look.
+
+## Basic Usage
+
+```blade
+<x-bladewind::centered-content size="tiny">
+
+    <x-bladewind::card>
+        this content is centered in this column
+    </x-bladewind::card>
+
+</x-bladewind::centered-content>
+```
+
+```blade
+<x-bladewind::centered-content size="small">
+
+    <x-bladewind::card>
+        this content is centered in this column
+    </x-bladewind::card>
+
+</x-bladewind::centered-content>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| size | `xl` | Size of the centered container. Available values: `tiny` `small` `medium` `big` `xl` `xxl` `omg` |
+
+## Full Example
+
+```blade
+<x-bladewind::centered-content
+    size="medium"/>
+```

--- a/mcp/chart.md
+++ b/mcp/chart.md
@@ -1,0 +1,336 @@
+---
+title: Chart Component
+component: x-bladewind::chart
+url: /component/chart
+---
+
+# Chart
+
+The chart component relies on the [Chart.js](https://www.chartjs.org) library to display various aesthetically pleasing types of charts. The bar chart is the default but changing the type of chart is as simple as setting the `type` attribute to any of the acceptable chart types provided by [Chart.js](https://www.chartjs.org).
+
+## Basic Usage
+
+```blade
+<?php
+    $labels = ['Red', 'Blue', 'Yellow', 'Green', 'Purple'];
+    $data = [12, 19, 13, 15, 9, 10];
+```
+
+```blade
+<x-bladewind::chart :labels="$labels" :data="$data" title="Colour ranks" />
+```
+
+## Common Chart Options
+
+There are four top level options in the [Chart.js configuration](https://www.chartjs.org/docs/latest/configuration/). These are `type`, `data`, `options` and `plugins`. BladewindUI offers attributes that correspond to each of the above mentioned options in the Chart.js top level. Passing each attribute expects you to have defined the data in a format Chart.js expects. For example, whatever array you pass into the `data` attribute will simply be formatted into JSON and passed to Chart.js as shown below.
+
+```js
+// chart.js configuration
+const config = {
+    type: '{{$type}}',
+    // $data was passed as an attribute to the chart component
+    data: @json($data),
+    options: @json($options),
+    plugins: @json($plugins)
+}
+```
+
+BladewindUI however, exposes a few common chart options that can be passed as attributes for convenience.
+
+| Attribute | Description |
+|---|---|
+| show_axis_lines | show the lines on both the x and y axes |
+| show_x_axis_lines | show the lines on the x axis |
+| show_y_axis_lines | show the lines on the y axis |
+| show_axis_labels | show the labels on both the x and y axes |
+| show_x_axis_labels | show the labels on the x axis |
+| show_y_axis_labels | show the labels on the y axis |
+| show_borders | show the borders around the chart. These are the main x and y axes lines. |
+| show_x_border | show the border on the x axis |
+| show_y_border | show the border on the y axis |
+| title | title of the chart |
+| show_legend | display the chart legend |
+| legend_position | where should the legend be placed |
+| legend_alignment | how should the legend text be aligned |
+| bg_color | where applicable, this defines the background colour of the charts not the canvas |
+| border_color | where applicable, this defines the border colour of the charts |
+| border_width | where applicable, this defines how thick the border of each chart item should be |
+
+> When you define both the `labels` and `data` attributes, `data` is treated as the chart data you want to display NOT the entire top level `data` object where you can define datasets, labels, border colours and many more options.
+
+```blade
+<x-bladewind::chart
+    type="bar"
+    :labels="$labels"
+    :data="$data"
+    title=""
+    show_legend="false"
+    show_borders="false"
+    show_axis_lines="false"
+    show_axis_labels="false" />
+```
+
+## Chart Types
+
+### Area Chart
+
+Set `type="area"` to display an area chart.
+
+```blade
+<x-bladewind::chart
+    type="area"
+    :labels="$labels" :data="$data" show_legend="false" />
+```
+
+### Bar Chart
+
+Set `type="bar"` to display a bar chart. This is the default.
+
+```blade
+<x-bladewind::chart
+    type="bar"
+    :labels="$labels" :data="$data" show_legend="false" />
+```
+
+### Bubble Chart
+
+Set `type="bubble"` to display a bubble chart.
+
+```blade
+<?php
+$bubble_labels = [];
+$bubble_data = [
+    ['x' => 5, 'y' => 10, 'r' => 8],
+    ['x' => 10, 'y' => 15, 'r' => 6],
+    ...
+    ['x' => 85, 'y' => 26, 'r' => 7],
+    ['x' => 100, 'y' => 30, 'r' => 10],
+];
+```
+
+```blade
+<x-bladewind::chart
+    type="bubble"
+    bg_color="rgba(153, 102, 255, 0.5)"
+    border_color="rgb(153, 102, 255)"
+    :labels="$bubble_labels" :data="$bubble_data" show_legend="false" />
+```
+
+### Doughnut Chart
+
+Set `type="doughnut"` to display a doughnut chart.
+
+```blade
+<x-bladewind::chart
+    type="doughnut"
+    :labels="$labels" :data="$data" show_legend="false" />
+```
+
+### Line Chart
+
+Set `type="line"` to display a line chart.
+
+```blade
+<x-bladewind::chart
+    type="line" border_width="5"
+    :labels="$labels" :data="$data" show_legend="false" />
+```
+
+### Pie Chart
+
+Set `type="pie"` to display a pie chart.
+
+```blade
+<x-bladewind::chart
+    type="pie"
+    :labels="$labels" :data="$data" show_legend="false" />
+```
+
+### Polar Chart
+
+Set `type="polar"` to display a polar chart.
+
+```blade
+<x-bladewind::chart
+    type="polar"
+    :labels="$labels" :data="$data" show_legend="false" />
+```
+
+### Radar Chart
+
+Set `type="radar"` to display a radar chart.
+
+```blade
+<?php
+$radar_labels = ['Speed', 'Strength', 'Agility', 'Endurance', 'Skill'];
+$radar_data = [65, 59, 90, 81, 56]
+```
+
+```blade
+<x-bladewind::chart
+    type="radar"
+    bg_color="rgba(54, 162, 235, 0.3)"
+    border_color="#36A2EB" border_width="2"
+    :labels="$radar_labels" :data="$radar_data" show_legend="false" />
+```
+
+### Scatter Chart
+
+Set `type="scatter"` to display a scatter chart.
+
+```blade
+<?php
+$scatter_labels = [];
+$scatter_data = [
+    ['x' => -15, 'y' => 10],
+    ['x' => -5, 'y' => 5],
+    ...
+    ['x' => 30, 'y' => 13],
+    ['x' => 32, 'y' => 10],
+]
+```
+
+```blade
+<x-bladewind::chart
+    type="scatter"
+    :labels="$scatter_labels" :data="$scatter_data" show_legend="false" />
+```
+
+Scatter charts can have lines connecting the dots. This is turned off by default and can be displayed by setting `show_line="true"`. This attribute only applies to scatter charts.
+
+```blade
+<x-bladewind::chart
+    type="scatter" show_line="true"
+    :labels="$scatter_labels" :data="$scatter_data" show_legend="false" />
+```
+
+### Mixed Charts
+
+To define a mixture of chart types, you need to create your own chart data array that includes data for all the chart types you want to display. You then pass this array to the `data` attribute. [See this page for more details.](https://www.chartjs.org/docs/latest/charts/mixed.html)
+
+```blade
+<?php
+$data = [
+    "labels" => ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+    "datasets" => [
+        [
+            'type' => 'bar',
+            'label' => 'Sales',
+            'data' => [10, 20, 30, 25, 15],
+            'backgroundColor' => 'rgba(54, 162, 235, 0.2)',
+            'borderColor' => 'rgb(75, 192, 192)',
+        ],
+        [
+            'type' => 'line',
+            'label' => 'Trend',
+            'data' => [12, 18, 28, 22, 17],
+            'borderColor' => '#FF6384',
+            'borderWidth' => 2,
+            'fill' => false,
+        ]
+    ]
+];
+```
+
+```blade
+<x-bladewind::chart :data="$data"  />
+```
+
+## Chart Data
+
+All data is passed to the chart via the `data` attribute, but there are two ways to define this data.
+
+### Option 1
+
+This requires you to set values for both the `labels` and `data` attributes. The data in this case should only be the data points to be displayed in the chart. Each data point is matched against a corresponding label depending on the type of chart being displayed.
+
+```blade
+<?php
+    $labels = ['Red', 'Blue', 'Yellow', 'Green', 'Purple'];
+    $data = [12, 19, 13, 15, 9, 10];
+```
+
+```blade
+<x-bladewind::chart :labels="$labels" :data="$data" />
+```
+
+### Option 2
+
+This requires you to define the entire chart datasets in an array and pass that to the `data` attribute. This option is recommended if you require more flexibility with the properties you want to define in the [Chart.js configurations](https://www.chartjs.org/docs/latest/configuration/). When using this option, the only attributes available to the chart component are `data`, `options` and `plugins`. All other attributes are ignored since they will need to be defined in your data array.
+
+```blade
+<?php
+$data = [
+    "labels" => ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+    "datasets" => [
+        [
+            'type' => 'bar',
+            'label' => 'Sales',
+            'data' => [10, 20, 30, 25, 15],
+            'backgroundColor' => 'rgba(54, 162, 235, 0.2)',
+            'borderColor' => 'rgb(75, 192, 192)',
+        ],
+        [
+            'type' => 'line',
+            'label' => 'Trend',
+            'data' => [12, 18, 28, 22, 17],
+            'borderColor' => '#FF6384',
+            'borderWidth' => 2,
+            'fill' => false,
+        ]
+    ]
+];
+```
+
+```blade
+<x-bladewind::chart :data="$data"  />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | random | The name of the chart for DOM accessibility |
+| labels | `[]` | An array of labels to display in the chart |
+| data | `[]` | An array of data points to display in the chart. Alternatively, this can be a comprehensive array of chart data and other properties |
+| options | `[]` | An array of chart options as provided in the [Chart.js documentation](https://www.chartjs.org/docs/latest/general/options.html) |
+| plugins | `[]` | An array of plugin options as provided in the [Chart.js documentation](https://www.chartjs.org/docs/latest/general/options.html) |
+| type | `bar` | Type of chart to display: `area` `bar` `bubble` `doughnut` `line` `pie` `polar` `radar` `scatter` |
+| show_axis_lines | `true` | Show the lines on both the x and y axes. `true` `false` |
+| show_x_axis_lines | `true` | Show the lines on the x axis. `true` `false` |
+| show_y_axis_lines | `true` | Show the lines on the y axis. `true` `false` |
+| show_axis_labels | `true` | Show the labels on both the x and y axes. `true` `false` |
+| show_x_axis_labels | `true` | Show the labels on the x axis. `true` `false` |
+| show_y_axis_labels | `true` | Show the labels on the y axis. `true` `false` |
+| show_borders | `true` | Show the borders around the chart. These are the main x and y axes lines. `true` `false` |
+| show_x_border | `true` | Show the border on the x axis. `true` `false` |
+| show_y_border | `true` | Show the border on the y axis. `true` `false` |
+| show_line | `false` | Only applicable to scatter charts. Show the line that connects the dots. `true` `false` |
+| title | blank | Title of the chart |
+| show_legend | `true` | Display the chart legend. `true` `false` |
+| legend_position | `top` | Where should the legend be placed. `top` `right` `bottom` `left` `chartArea` |
+| legend_alignment | `center` | How should the legend text be aligned. `start` `center` `end` |
+| bg_color | blank | Defines the background colour of the charts not the canvas. Accepts rgb, hex and normal colour names. e.g. `green` `#fff333` `rgba(0, 0, 0, 0.1)` |
+| border_color | blank | Defines the border colour of the charts. Accepts rgb, hex and normal colour names. e.g. `green` `#fff333` `rgba(0, 0, 0, 0.1)` |
+| border_width | `1` | Defines how thick the border of each chart item should be. Must be numeric value above 0 |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts |
+
+## Full Example
+
+```blade
+<x-bladewind::chart
+    :labels="$labels"
+    :data="$data"
+    :options="$options"
+    :plugins="$plugins"
+    name="population"
+    type="line"
+    bg_color="green"
+    border_color="yellow"
+    border_width="3"
+    show_axis_lines="false"
+    show_axis_labels="false"
+    show_borders="false"
+    show_legend="false"
+    title="Population Distribution" />
+```

--- a/mcp/checkbox.md
+++ b/mcp/checkbox.md
@@ -1,0 +1,100 @@
+---
+title: Checkbox Component
+component: x-bladewind::checkbox
+url: /component/checkbox
+---
+
+# Checkbox
+
+Display a checkbox with or without a label. The default checkbox colour is blue but there are nine colours available to choose from.
+
+## Basic Usage
+
+```blade
+<x-bladewind::checkbox  />
+```
+
+```blade
+<x-bladewind::checkbox label="I agree to the terms and conditions"  />
+```
+
+Labels can include HTML such as links:
+
+```blade
+<x-bladewind::checkbox
+    label="I agree to the <a href='/terms'>terms and conditions</a>"  />
+```
+
+Checkboxes can be checked by default:
+
+```blade
+<x-bladewind::checkbox
+    label="I am checked by default"
+    checked="true"  />
+```
+
+Checkboxes can be disabled:
+
+```blade
+<x-bladewind::checkbox
+    label="I am disabled"
+    disabled="true"  />
+```
+
+## Coloured Checkboxes
+
+Like most of the BladewindUI components, checkboxes also come in nine colours to enable the components sit better in most designs with various colour schemes.
+
+```blade
+<x-bladewind::checkbox color="red" checked="true" label="I am a red checkbox" />
+<x-bladewind::checkbox color="yellow" checked="true" label="I am a yellow checkbox" />
+<x-bladewind::checkbox color="green" checked="true" label="I am a green checkbox" />
+<x-bladewind::checkbox color="pink" checked="true" label="I am a pink checkbox" />
+<x-bladewind::checkbox color="cyan" checked="true" label="I am a cyan checkbox" />
+<x-bladewind::checkbox color="black" checked="true" label="I am a black checkbox" />
+<x-bladewind::checkbox color="purple" checked="true" label="I am a purple checkbox" />
+<x-bladewind::checkbox color="orange" checked="true" label="I am a orange checkbox" />
+<x-bladewind::checkbox color="blue" checked="true" label="I am a blue checkbox" />
+<x-bladewind::checkbox color="violet" checked="true" label="I am a violet checkbox" />
+<x-bladewind::checkbox color="indigo" checked="true" label="I am a indigo checkbox" />
+<x-bladewind::checkbox color="fuchsia" checked="true" label="I am a fuchsia checkbox" />
+```
+
+## Checkboxes and Forms
+
+When using checkboxes with forms, it is always good practice to give the checkbox a name and value. That way, when the form is submitted, the value of the checkbox can be retrieved from its name. It is important to note that, in some cases, if the user does not select the checkbox, the name of the checkbox will be ignored completely from your payload.
+
+```blade
+<x-bladewind::checkbox
+    name="notify_me"
+    value="1"
+    label="Send me weekly newsletters" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | `checkbox` | This name can be accessed when the checkbox is submitted in the form. The name is also available as part of the css classes |
+| label | blank | Text to be displayed next to the checkbox |
+| value | blank | In case you are editing a form, the value passed will be set on the value attribute of the checkbox |
+| checked | `false` | Specifies whether the checkbox is checked or not. Value needs to be set as a string not boolean. `true` `false` |
+| disabled | `false` | Specifies whether the checkbox is disabled or not. Value needs to be set as a string not boolean. `true` `false` |
+| add_clearing | `true` | Adds a margin to the bottom of the checkbox to separate it from the next form element. `true` `false` |
+| color | `primary` | Color of the checkbox rings. `primary` `red` `yellow` `green` `blue` `black` `cyan` `orange` `purple` `pink` `violet` `indigo` `fuchsia` |
+| class | `bw-checkbox` | Any additional css classes can be added using this attribute |
+| label_css | `mr-6` | Applies styling to the checkbox label |
+
+## Full Example
+
+```blade
+<x-bladewind::checkbox
+    label="I agree to the terms and conditions"
+    checked="false"
+    disabled="false"
+    name="tnc"
+    value="yes"
+    color="pink"
+    label_css="font-bold"
+    class="shadow-sm" />
+```

--- a/mcp/checkcard.md
+++ b/mcp/checkcard.md
@@ -1,0 +1,254 @@
+---
+title: CheckCard Component
+component: x-bladewind::checkcards
+url: /component/checkcard
+---
+
+# CheckCard
+
+This component is simply a prettier version of checkboxes. Define content in a card that needs to be checkable and give it a `value`. This value is what will be passed when the form is selected. In its simplest form this is just a card with content you provide.
+
+The selectable card takes up the width of its parent element. If you don't want the cards to take up the entire width you will need to restrict this using flex or grids.
+
+## Basic Usage
+
+```blade
+<x-bladewind::checkcards name="hosting">
+    <x-bladewind::checkcards.card value="dOcean">
+        DigitalOcean
+    </x-bladewind::checkcards.card>
+</x-bladewind::checkcards>
+```
+
+For convenience the component provides a `title` attribute that can also be passed in as a slot if you prefer some more customized styling of the title.
+
+```blade
+<x-bladewind::checkcards name="hosting-3" max="3">
+    <div class="grid grid-cols-2 gap-4">
+        <x-bladewind::checkcards.card value="AWS"
+            title="Amazon Web Services">
+            A subsidiary of Amazon that provides on-demand ...
+        </x-bladewind::checkcards.card>
+    ...
+    </div>
+</x-bladewind::checkcards>
+```
+
+### Compact Mode
+
+```blade
+<x-bladewind::checkcards name="hosting-compact" compact="true">
+    <x-bladewind::checkcards.card value="dOcean">
+        DigitalOcean
+    </x-bladewind::checkcards.card>
+</x-bladewind::checkcards>
+```
+
+## Max Selection
+
+By default only one card can be selected at a time. You can increase this by setting the `max` attribute to a positive integer greater than zero. The example below sets `max="3"`, meaning only 3 cards can be selected.
+
+```blade
+<x-bladewind::checkcards name="hosting-small" max="3">
+    <div class="grid grid-cols-3 gap-4">
+        <x-bladewind::checkcards.card name="hosting" value="AWS">
+            Amazon Web Services
+        </x-bladewind::checkcards.card>
+
+        <x-bladewind::checkcards.card name="hosting" value="azure">
+            Microsoft Azure
+        </x-bladewind::checkcards.card>
+
+        <x-bladewind::checkcards.card name="hosting" value="dOcean">
+            DigitalOcean
+        </x-bladewind::checkcards.card>
+    ...
+    </div>
+</x-bladewind::checkcards>
+```
+
+### Max Selection Error Messages
+
+If the user tries to select a card when the max has already been selected, you can either display an error message or say nothing. By default no error message is displayed. To display errors you will need to set `show_error="true"`. The error message is displayed in the [Notification](/component/notification) component. Ensure this component is included on any page where you want to use Checkable cards with errors. The actual error message to display can be defined by setting the `error_heading` and `error_message` attributes. If you don't specify these two attributes, the defaults will be used.
+
+```blade
+<x-bladewind::checkcards
+    name="hosting-auto"
+    show_error="true"
+    max="3"
+    auto_select_new="false">
+    <div class="grid grid-cols-3 gap-4">
+        <x-bladewind::checkcards.card name="hosting" value="AWS">
+            Amazon Web Services
+        </x-bladewind::checkcards.card>
+    ...
+    </div>
+</x-bladewind::checkcards>
+```
+
+## Automatically Select New Cards
+
+From the max selection example above, you will notice every time three cards are selected, clicking on a fourth card automatically clears the third card that was previously selected. This is the default behaviour, to always preserve the number of cards you want selected without blocking the user. If you prefer to prevent users from selecting new cards when the max has been reached, set `auto_select_new="false"`. Users will now need to unselect one card to make room for a new selection.
+
+```blade
+<x-bladewind::checkcards
+    name="hosting-auto"
+    show_error="true"
+    max="3"
+    auto_select_new="false">
+    <div class="grid grid-cols-3 gap-4">
+        <x-bladewind::checkcards.card name="hosting" value="AWS">
+            Amazon Web Services
+        </x-bladewind::checkcards.card>
+    ...
+    </div>
+</x-bladewind::checkcards>
+```
+
+## Icons and Avatars
+
+By design the Checkcard component simply makes it easy for you to have checkboxes designed as cards. The content of the card solely relies on you. However, for convenience, the component allows you to specify an icon to use in the card. This uses the [Icon](/component/icon) component with some features stripped out. To use an icon, simply specify the name of the icon you want to use in the `icon` attribute. The `icon_css` attribute allows you to specify additional CSS classes for the icon.
+
+The colour of the icon is determined by the value of the `color` attribute. The default value is `primary`. You can specify any of the [colours](/customize/colours) available in BladewindUI.
+
+```blade
+<x-bladewind::checkcards name="hosting-icons">
+    <div class="grid grid-cols-2 gap-4">
+        <x-bladewind::checkcards.card
+            value="AWS" title="AWS"
+            icon="cloud-arrow-up">
+            A copy of your messages will be backed up to Amazon Web Services ...
+        </x-bladewind::checkcards.card>
+        <x-bladewind::checkcards.card value="gdrive" title="Google Drive"
+            icon="circle-stack">
+            A copy of your messages will be backed up to Google Drive ...
+        </x-bladewind::checkcards.card>
+    </div>
+</x-bladewind::checkcards>
+```
+
+### Avatars
+
+Avatars can be used instead of icons. This also relies on a stripped down version of the BladewindUI [Avatar](/component/avatar) component. When an avatar name is three characters or less, a label is used instead of an image. The colour of the avatar is determined by the value of the `color` attribute. The default value is `primary`. You can specify any of the [colours](/customize/colours) available in BladewindUI.
+
+```blade
+<x-bladewind::checkcards name="hosting-avatar" max="2">
+    <div class="grid grid-cols-2 gap-4">
+        <x-bladewind::checkcards.card
+            value="mike" title="Michael Ocansey"
+            avatar="/assets/images/me.jpeg">
+            Follow Michael K. Ocansey to know when they post a...
+        </x-bladewind::checkcards.card>
+        <x-bladewind::checkcards.card
+            value="francis"
+            title="Francis Appiah"
+            avatar="/assets/images/francis.png">
+            Follow Francis Appiah to know when they post any new ...
+        </x-bladewind::checkcards.card>
+    </div>
+</x-bladewind::checkcards>
+```
+
+## Colours
+
+The border colour can be changed by setting the `border_color` attribute. The colour of icons and avatar labels can also be changed by setting the `color` attribute. You can specify any of the [colours](/customize/colours) available in BladewindUI. The checkmark icon colour changes to match the colour of the border.
+
+```blade
+<x-bladewind::checkcards name="hosting-colours"
+    border_color="orange" color="orange">
+    <div class="grid grid-cols-2 gap-4">
+        <x-bladewind::checkcards.card
+            value="AWS" title="AWS" icon="cloud-arrow-up">
+            Your messages will be backed up to Amazon Web Services.
+        </x-bladewind::checkcards.card>
+        ...
+    </div>
+</x-bladewind::checkcards>
+```
+
+## Form Submission
+
+Checkable cards can be used within forms as a substitute for checkboxes or radio buttons. The `name` specified is what will be accessed when the form is submitted. Selecting multiple values results in a comma separated list being passed when the form is submitted.
+
+Using the **hosting** name from our examples above, after submitting the form the value of the hosting checkcards can be accessed using any of the following ways permitted in Laravel.
+
+```blade
+$request->get('hosting');
+$request->input('hosting');
+$request->hosting;
+```
+
+## Attributes
+
+### Checkcards Component
+
+This is the parent tag for defining Checkcards.
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | null | Name to be accessed when checkcard selections are submitted in a form. |
+| color | gray | `primary` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` \| `indigo` \| `fuchsia` \| `violet` |
+| max | 1 | How many checkcards can be selected at a time. Any positive number > 0. |
+| required | false | Determines if checkcards are required when displayed in a form. `true` \| `false` |
+| selected_value | _(empty string)_ | In edit mode you will want selected checkcards to be selected by default. Set the values as a comma separated list. |
+| error_message | _(empty string)_ | Message to display when `max` is set and user selection exceeds the max allowed. |
+| error_heading | Error | Heading to display in the notification when displaying an error message. |
+| icon | null | Display an icon prefix. You can use any icon from Heroicons. |
+| avatar | null | Display an avatar as an image or label. If this is less than 4 characters, the avatar will be displayed as a label. |
+| avatar_size | medium | Determine size of the avatar to display. `tiny` \| `small` \| `medium` \| `regular` \| `big` \| `huge` \| `omg` |
+| compact | false | Should the checkcards be displayed with less padding around them. `true` \| `false` |
+| border_color | gray | `blue` \| `red` \| `yellow` \| `green` \| `purple` \| `pink` \| `orange` \| `gray` \| `cyan` \| `violet` \| `indigo` \| `fuchsia` |
+| border_width | 2 | How thick should the border of the card be. `2` \| `4` \| `8` |
+| radius | medium | Determines the roundness of the card. `none` \| `small` \| `medium` \| `full` |
+| show_error | false | Should error messages be displayed when user has selected `max` cards. `true` \| `false` |
+| align_items | top | Determines alignment of avatar/icons. `top` \| `center` |
+| auto_select_new | true | Determines if selecting a new card unselects the last card. This ensures the user always selects `max` cards without displaying an error. `true` \| `false` |
+| class | _(blank)_ | Any additional CSS you wish to add to the checkcards container. |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. |
+
+### Checkcard Component
+
+| Attribute | Default | Description |
+|---|---|---|
+| class | _(blank)_ | Any additional CSS to append to the card. |
+| title | _(blank)_ | The text to display as title of the card. |
+| value | _(blank)_ | Value to pass when card is selected and form is submitted. |
+| icon | null | Display an icon prefix. You can use any icon from Heroicons. |
+| avatar | null | Display an avatar as an image or label. If this is less than 4 characters, the avatar will be displayed as a label. |
+| avatar_size | medium | Determine size of the avatar to display. `tiny` \| `small` \| `medium` \| `regular` \| `big` \| `huge` \| `omg` |
+| icon_css | _(blank)_ | Additional CSS to append to the icon. |
+
+## Full Example
+
+```blade
+<x-bladewind::checkcards
+    name="hosting"
+    icon="calculator",
+    avatar="OK",
+    avatar_size="medium",
+    class="",
+    required="false",
+    max="3",
+    compact="false",
+    color="primary",
+    radius="medium",
+    border_width="2",
+    border_color="gray",
+    align_items="top",
+    show_error="false",
+    auto_select_new="true",
+    selected_value="azure,google"
+    error_message="You can select only up to 3 companies"
+    error_heading="Check selection!">
+```
+
+```blade
+<x-bladewind::checkcards.card
+    title="Amazon Web Services"
+    value="aws"
+    icon="calculator",
+    avatar="OK",
+    avatar_size="medium",
+    class=""
+    icon_css="size-13" />
+```

--- a/mcp/colorpicker.md
+++ b/mcp/colorpicker.md
@@ -1,0 +1,76 @@
+---
+title: Colorpicker Component
+component: x-bladewind::colorpicker
+url: /component/colorpicker
+---
+
+# Colorpicker
+
+Display a colour picker so users can select a colour. There are two types of colour pickers. The default HTML colour picker is the default displayed by this component. Once you pass a comma separated string of colours, a custom colour picker is displayed instead.
+
+## Basic Usage
+
+```blade
+<x-bladewind::colorpicker  />
+```
+
+Once you pass a comma separated string of colours, a custom colour picker is displayed instead. These must be HEX colours including the '#' sign. This is useful if you are building a theme based web app that allows users to select their preferred theme for example.
+
+```blade
+<x-bladewind::colorpicker
+ colors="#fff999, #cccccc, #999222, #787623, #78fcc3, #333678, #878987, #098765"/>
+```
+
+## Show Selected Value
+
+By default the colorpicker does not show the value of the selected colour. It only changes the colour of the box to what has been selected. To show the selected value set `show_value="true"`.
+
+```blade
+<x-bladewind::colorpicker show_value="true" />
+```
+
+## Sizes
+
+The colorpicker comes in different sizes to match with input fields. In case the component is being used in a form with other fields. The default size is regular.
+
+```blade
+<x-bladewind::colorpicker size="small"  />
+```
+
+```blade
+<x-bladewind::colorpicker size="regular"  />
+```
+
+```blade
+<x-bladewind::colorpicker size="medium"  />
+```
+
+```blade
+<x-bladewind::colorpicker size="big"  />
+```
+
+In order to access selected colour values when a form is submitted, provide a `name` for your colorpicker. BladewindUI provides a random unique name when no name is provided.
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | random | This name can be accessed when the colorpicker is submitted in a form. |
+| selected_value | #000000 | The default colour to show in the colorpicker. Also used when editing an already saved value. |
+| show_value | false | Determines if the component should show the selected colour value. `true` \| `false` |
+| class | _(blank)_ | Any additional css classes can be added using this attribute. |
+| colors | _(blank)_ | Comma separated list of colours to display instead of the default colour palette. |
+| size | regular | Size of the colorpicker. Values match the various input size values. `small` \| `regular` \| `medium` \| `big` |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. |
+
+## Full Example
+
+```blade
+<x-bladewind::colorpicker
+    name="theme"
+    size="medium"
+    show_value="true"
+    colors="#989098, #cccc44, #323232"
+    selected_value="#909090"
+    class="shadow-sm" />
+```

--- a/mcp/datepicker.md
+++ b/mcp/datepicker.md
@@ -1,0 +1,126 @@
+---
+title: Datepicker Component
+component: x-bladewind::datepicker
+url: /component/datepicker
+---
+
+# Datepicker
+
+Display a datepicker so user can select a date. The datepicker component is locale friendly. Months and days of the week are translated.
+
+## Basic Usage
+
+```blade
+<x-bladewind::datepicker  />
+```
+
+By default the datepicker fills up the width of its parent container. You can however specify a width of your choice using the datepicker's `css` attribute.
+
+You can also change the placeholder text from the default `Select a date`.
+
+```blade
+<div class="w-40">
+    <x-bladewind::datepicker placeholder="Invoice Date"  />
+</div>
+```
+
+## Range Calendar
+
+The range datepicker allows you to select a range of dates by setting `range="true"`. In the input field, the range of dates selected are separated with a dash (-). For example, a selected date range will be displayed in the input as **2025-01-10 - 2025-01-31**.
+
+```blade
+<x-bladewind::datepicker range="true"  />
+```
+
+### Show As a Required Field
+
+An asterisk is appended to the placeholder text when `required="true"`.
+
+```blade
+<x-bladewind::datepicker required="true"  />
+```
+
+## Date Formats
+
+You can specify how you want dates selected in the datepicker to be displayed. There are four options to pick from. The default format is `format="yyyy-mm-dd"`. When using a range datepicker, the format you specify is applied to both datepickers.
+
+```blade
+<x-bladewind::datepicker name="date1" type="range" format="dd-mm-yyyy" />
+```
+
+```blade
+<x-bladewind::datepicker name="date2" format="mm-dd-yyyy" />
+```
+
+```blade
+<x-bladewind::datepicker name="date3" format="D d M, Y" type="range" />
+```
+
+```blade
+<x-bladewind::datepicker name="date4" format="yyyy-mm-dd" />
+```
+
+## With Default Values
+
+There are times you will want the datepicker to load prepopulated with a default value. This is useful when in edit mode or when using filters and you want to show the user what dates they filtered by.
+
+```blade
+<x-bladewind::datepicker selected_value="2021-12-03"  />
+```
+
+It is possible to have default dates for a range datepicker also.
+
+```blade
+<x-bladewind::datepicker range="true" selected_value="2021-12-03 - 2022-01-03"  />
+```
+
+## Min and Max Dates
+
+Setting minimum and maximum dates restrict the datepicker to display dates only within these specified dates. The `min_date` attribute allows you to set the accepted minimum date. Any dates before this date will be disabled and grayed out. The `max_date` attribute allows you to set the accepted maximum date. Any dates after this date will be disabled and grayed out.
+
+```blade
+<x-bladewind::datepicker min_date="{{date('Y-m-d')}}" />
+```
+
+```blade
+<x-bladewind::datepicker max_date="{{date('Y-m-t')}}" />
+```
+
+```blade
+<x-bladewind::datepicker min_date="{{date('Y-m-01')}}" max_date="{{date('Y-m-t')}}" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | bw-datepicker | This name can be accessed when the input is submitted in the form. The name is also available as part of the css classes. |
+| range | false | Allow range selection. `true` \| `false` |
+| selected_value | _(blank)_ | In case you are editing a form, the value passed will be set on the value attribute of the datepicker input. |
+| min_date | _(blank)_ | Restrict the date to start from this. Any dates before this will be disabled and grayed out. |
+| max_date | _(blank)_ | Restrict the date to end at this. Any dates after this will be disabled and grayed out. |
+| format | yyyy-mm-dd | How date should be formatted. `yyyy-mm-dd` \| `dd-mm-yyyy` \| `mm-dd-yyyy` \| `yyyy/mm/dd` \| `dd/mm/yyyy` \| `mm/dd/yyyy` \| `D d M, Y` |
+| placeholder | Select a date | Placeholder text to display. |
+| label | Select a date | Label text to display. |
+| required | false | Determines if the placeholder text should have an asterisk appended to it or not. `true` \| `false` |
+| week_starts | sunday | Choose between Sunday and Monday as the first day of the week. `sunday` \| `monday` |
+| class | bw-datepicker | Any additional css classes can be added using this attribute. |
+| size | medium | Sizing of the input to match button sizes. `tiny` \| `small` \| `regular` \| `big` |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. |
+
+## Full Example
+
+```blade
+<x-bladewind::datepicker
+    name="invoice_date"
+    range="true"
+    required="false"
+    placeholder="Invoice Date"
+    selected_value=""
+    format="dd/mm/yyyy"
+    min_date="01/11/2025"
+    max_date="01/12/2025"
+    week_starts="monday"
+    size="big"
+    class="shadow-sm" />
+```

--- a/mcp/dropmenu.md
+++ b/mcp/dropmenu.md
@@ -1,0 +1,253 @@
+---
+title: Dropmenu Component
+component: x-bladewind::dropmenu
+url: /component/dropmenu
+---
+
+# Dropmenu
+
+Useful for displaying menu items in a dropdown. This is very different from the [Select component](/component/select). The Select component can pass values as a form element. The Dropmenu does not pass values around and is mostly useful for accessing quick actions.
+
+```blade
+<x-bladewind::dropmenu>
+    <x-bladewind::dropmenu.item>Invite to Project</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Assign Task</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Send Message</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+```
+
+By default the Dropmenu is triggered using the `horizontal ellipsis` icon found on [Heroicons](https://heroicons.com/). You can trigger the menu using any other icon from Heroicons or using any other element. To use an icon as the trigger, the trick is to append the word **-icon** to the end of the name of the icon defined on Heroicons.
+
+```blade
+<x-bladewind::dropmenu trigger="musical-note-icon">
+    <x-bladewind::dropmenu.item>Add to playlist</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Play again</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+
+<x-bladewind::dropmenu trigger="arrow-down-circle-icon">
+    <x-bladewind::dropmenu.item>Download file</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Add to library</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+
+<x-bladewind::dropmenu trigger="cog-6-tooth-icon">
+    <x-bladewind::dropmenu.item>Company settings</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>User settings</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+```
+
+## Trigger Properties
+
+### trigger_css
+
+It is also possible to modify the trigger css. This css applies to any item you specify as the trigger but most useful if you specify an icon as the trigger. This is achieved by defining TailwindCSS classes for the `trigger_css` attribute.
+
+```blade
+<x-bladewind::dropmenu trigger="musical-note-icon"
+     trigger_css="bg-pink-600 text-white p-2 rounded-full !h-10 !w-10">
+    <x-bladewind::dropmenu.item>Add to playlist</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Play again</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+```
+
+### trigger_on
+
+By default the Dropmenu is displayed when you click on the trigger. It is possible to change this behaviour by defining the `trigger_on` attribute. There are only two available options: `click` and `mouseover`.
+
+```blade
+<x-bladewind::dropmenu trigger="musical-note-icon"
+    trigger_css="bg-green-600 text-white p-2 rounded-full !h-10 !w-10"
+    trigger_on="mouseover">
+    <x-bladewind::dropmenu.item>Add to playlist</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Play again</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+```
+
+### Non Icon Triggers
+
+To trigger the Dropmenu using any HTML element other than an icon, you will need to define the trigger as a slot.
+
+```blade
+<x-bladewind::dropmenu>
+    <x-slot:trigger>
+        <x-bladewind::button type="secondary" size="tiny">Options</x-bladewind::button>
+    </x-slot:trigger>
+    <x-bladewind::dropmenu.item>Add to playlist</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Play again</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+
+<x-bladewind::dropmenu>
+    <x-slot:trigger>
+        <div class="flex space-x-2 items-center shadow px-4 rounded-md">
+            <div class="grow">
+                <x-bladewind::avatar image="/assets/images/francis.png" />
+            </div>
+            <div class="grow">
+                <div><strong>John C. Doe</strong></div>
+                <div class="text-sm">Tech, IT Support</div>
+            </div>
+            <div>
+                <x-bladewind::icon name="chevron-down" class="!h-4 !w-4" />
+            </div>
+        </div>
+    </x-slot:trigger>
+    <x-bladewind::dropmenu.item>Deactivate my account</x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item>Delete Profile</x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+```
+
+## Dropmenu Item Actions
+
+The Dropmenu items are the actual line items within your Dropmenu. Each item can contain any piece of HTML code so you completely have control over what action is assigned to each menu item. BladewindUI does not interfere. For convenience, you can specify an `onclick` attribute.
+
+Dropmenu Items can contain HTML so their content is all up to you.
+
+```blade
+<x-bladewind::dropmenu trigger="light-bulb-icon"
+    trigger_css="bg-yellow-400 text-yellow-800 p-2 rounded-full !h-10 !w-10">
+    <x-bladewind::dropmenu.item>
+        <a href="/library" target="_blank">Go to Library</a>
+    </x-bladewind::dropmenu.item>
+    <x-bladewind::dropmenu.item onclick="showModal('dropmenu-demo')">
+        Show a Modal
+    </x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+```
+
+## Headers, Icons and Dividers
+
+### Headers
+
+It is possible to define a header for your Dropmenu component. There can be several headers in a Dropmenu. The header is still a `x-bladewind::dropmenu.item` component so can contain any HTML. The only difference between this and other items is there is no hover effect, the cursor displayed is the default pointer and there is a divider separating the header from the next menu item. To define a Dropmenu item as a header, set `header="true"`.
+
+```blade
+<x-bladewind::dropmenu.item header="true">
+    // define heading here
+</x-bladewind::dropmenu.item>
+```
+
+### Icons
+
+Even though it is possible to define your own icon as part of the Dropmenu item's content, there is a shortcut that allows you to define any of the icons available on [Heroicons](https://heroicons.com). This makes use of the BladewindUI [Icon component](/component/icon). This is useful only if you have menu items that fit on one line and you want to prefix each line with an icon. To define a Dropmenu item with an icon, set the `icon` attribute with any icon name from Heroicons. Unlike the icon used in the `trigger` attribute of the Dropmenu component, items do not require the **-icon** at the end of the icon name.
+
+```blade
+<x-bladewind::dropmenu.item icon="square-pencil">
+    Edit Profile
+</x-bladewind::dropmenu.item>
+```
+
+By default, icons are positioned on the left of the menu item content. To switch the icon position to the right of the menu item content, set `icon_right="true"`. Setting the attribute on the `x-bladewind::dropmenu` component will shift all menu items in the menu to the right. Alternatively, you can set the attribute on one or more menu items within the Dropmenu component.
+
+```blade
+<x-bladewind::dropmenu icon_right="true">
+    <x-bladewind::dropmenu.item>
+    ...
+    </x-bladewind::dropmenu.item>
+</x-bladewind::dropmenu>
+```
+
+### Dividers
+
+You may want to logically divide your Dropmenu into sections. You can either do that with headers or dividers. A divider is simply a non-clickable line separating menu items. To define a Dropmenu item as a divider, set `divider="true"`. Any text added to the menu item will be ignored.
+
+```blade
+<x-bladewind::dropmenu.item divider="true" />
+```
+
+By default Dropmenu Items are not divided. You can tell each menu item apart on mouseover. If you prefer to have your menu items separated by a thin gray line you can set `divided="true"` on the Dropmenu component itself (not on the menu items).
+
+```blade
+<x-bladewind::dropmenu divided="true">
+    ...
+</x-bladewind::dropmenu>
+```
+
+## Menu Position
+
+The Dropmenu component for now supports two menu positions: left and right. This is achieved by setting the `position` attribute on the Dropmenu component. The default position is `right` so you can ignore this attribute if you intend to use the component as is.
+
+```blade
+<x-bladewind::dropmenu position="left">
+...
+</x-bladewind::dropmenu>
+
+<x-bladewind::dropmenu position="right">
+...
+</x-bladewind::dropmenu>
+```
+
+## Scrollable Menu Items
+
+You could have a long list of menu items in your Dropmenu. If you don't want all items showing, you can set `scrollable="true"` on the Dropmenu component. This will reduce the menu items container to a default height of `200px` and scroll every menu item outside this view area. If the default height does not meet your needs, you can define your own height by setting the `height` attribute. This takes any positive integer without the "px".
+
+```blade
+<x-bladewind::dropmenu scrollable="true">
+...
+</x-bladewind::dropmenu>
+```
+
+If you have multiple Dropmenus on your page and experience issues with only the first Dropmenu showing and subsequent ones not showing, set `modular="true"` on the very first Dropmenu component on your page.
+
+## Attributes
+
+### Dropmenu Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| `name` | `uniqid('bw-dropmenu-')` | Optional unique name for the component. Usually useful if you wish to target a menu from CSS to define overwriting styles. |
+| `trigger` | `ellipsis-horizontal-icon` | The element to trigger the menu. Usually what a user will click on to show the menu. |
+| `trigger_css` | blank | Additional css to apply to the trigger. |
+| `trigger_on` | `click` | Which event should trigger the menu. `click` `mouseover` |
+| `divided` | `false` | Should menu items have lines dividing them. `true` `false` |
+| `scrollable` | `false` | Should menu items scroll after 200px. `true` `false` |
+| `height` | `200` | Default height for menu items container. When `scrollable=true`, menu items container will be restricted to this height. Accepts a positive integer. |
+| `hide_after_click` | `true` | Should the menu be hidden after clicking on any of the menu items. `true` `false` |
+| `icon_right` | `false` | Align the icon to the right of the menu item. Applies to all items in the menu. `true` `false` |
+| `class` | blank | Additional css for the menu items container. |
+| `position` | `right` | How should the menu items be positioned relative to the trigger. `right` `left` |
+| `padded` | `false` | Should the container for the menu items be padded. `true` `false` |
+| `modular` | `false` | Determines if script tags used within the component should have `type="module"`. Useful sometimes when working with Vite js. `true` `false` |
+| `nonce` | `null` | Used when implementing context security policies and require to pass a nonce to inline scripts. For convenience, you can set your `nonce` value in the `config/bladewind.php` file under the "script" key. |
+
+### Dropmenu Item Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| `icon` | blank | Any Heroicon icon to display as prefix to the menu item. |
+| `dir` | blank | Directory to load the icon from. See the [Icon](/component/icon#custom-dir) component for usage. |
+| `icon_css` | blank | Additional css to apply to the icon. |
+| `icon_right` | `false` | Align the icon to the right of the menu item. Applies to the menu item the attribute is declared on. `true` `false` |
+| `divider` | `false` | Is this menu item a divider. `true` `false` |
+| `header` | `false` | Is this menu item a header. `true` `false` |
+| `hover` | `true` | Should this menu item change its background colour on mouseover. `true` `false` |
+| `padded` | `false` | Should the menu item be padded. `true` `false` |
+| `class` | blank | Additional css to add to the menu item. |
+
+## Full Example
+
+```blade
+<x-bladewind::dropmenu
+    trigger="pencil-square-icon"
+    name="profile-menu"
+    trigger_css="!bg-yellow-400"
+    trigger_on="mouseover"
+    divided="true"
+    scrollable="true"
+    padded="true"
+    height="150"
+    hide_after_click="true"
+    position="left"
+    class="mt-0">
+
+    <x-bladewind::dropmenu.item
+        icon="pencil-square"
+        icon_css="text-red-400"
+        divider="false"
+        padded="false"
+        header="false"
+        hover="false"
+        class="p-2">
+    ...
+    </x-bladewind::dropmenu.item>
+
+</x-bladewind::dropmenu>
+```

--- a/mcp/empty-state.md
+++ b/mcp/empty-state.md
@@ -1,0 +1,102 @@
+---
+title: Empty State Component
+component: x-bladewind::empty-state
+url: /component/empty-state
+---
+
+# Empty State
+
+Display this when there is nothing to display. This prevents your users from seeing boring blank pages. The empty state component is intentionally minimal, bearing in mind that different applications have different empty state requirements.
+
+A default SVG image is bundled with BladewindUI at `public/vendor/bladewind/images/empty-state.svg` and used when no `image` attribute is specified.
+
+## Basic Usage
+
+```blade
+<x-bladewind::empty-state
+    message="Awesome! You have no documents to approve."
+    button_label="Go to Dashboard"
+    onclick="alert('you clicked me')">
+</x-bladewind::empty-state>
+```
+
+## Custom Image
+
+```blade
+<x-bladewind::empty-state
+    message="You have not saved any gists to your GitHub account"
+    image="/assets/images/no-code.svg"
+    button_label="Create Gist"
+    onclick="alert('you clicked me')">
+</x-bladewind::empty-state>
+```
+
+## With a Heading
+
+```blade
+<x-bladewind::empty-state
+    message="You have not saved any gists to your GitHub account"
+    heading="Create Gists Already"
+    image="/assets/images/no-code.svg"
+    button_label="Create Gist"
+    onclick="alert('you clicked me')">
+</x-bladewind::empty-state>
+```
+
+## Custom Content (No Image)
+
+Set `show_image="false"` to take full control of the empty state content via the default slot.
+
+```blade
+<x-bladewind::empty-state show_image="false">
+    <svg>...</svg>
+    <p class="pt-2">You have no biometric data available</p>
+    <x-bladewind::button color="red" size="small">
+        Add biometric info
+    </x-bladewind::button>
+</x-bladewind::empty-state>
+```
+
+## Without a Call to Action
+
+Omit `button_label` (or set it to an empty string) to display an empty state with no action button.
+
+```blade
+<x-bladewind::card title="Recent Activities" css="w-3/4 mx-auto">
+    <x-bladewind::empty-state
+        image="/assets/images/no-activity.svg"
+        message="Your recent activities list will take shape as soon as your organization has some activity">
+    </x-bladewind::empty-state>
+</x-bladewind::card>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| image | /vendor/bladewind/images/empty-state.svg | Image to display |
+| show_image | true | Show or hide the image. Set to `false` to control all content via slot. `true` \| `false` |
+| image_size | medium | Size of the image. `small` \| `medium` \| `large` \| `xl` \| `omg` |
+| for_select | false | Set to `true` when used inside a Select component. `true` \| `false` |
+| heading | _(blank)_ | Optional heading displayed above the message |
+| message | _(blank)_ | Main message text |
+| button_label | _(blank)_ | Text for the call to action button. Omit to hide the button |
+| onclick | _(blank)_ | JavaScript to execute when the button is clicked |
+| image_css | _(blank)_ | Additional TailwindCSS classes for the image |
+| class | bw-empty-state | Additional CSS classes for the wrapper |
+
+## Full Example
+
+```blade
+<x-bladewind::empty-state
+    message="Hey!! You cleaned up your inbox nicely"
+    button_label="Compose a message"
+    onclick="goToRoute('new-message')"
+    image="/assets/images/empty-inbox.png"
+    show_image="true"
+    heading="Nothing to see here"
+    size="xl"
+    image_css="!h-32"
+    class="shadow-sm">
+</x-bladewind::empty-state>
+```

--- a/mcp/filepicker.md
+++ b/mcp/filepicker.md
@@ -1,0 +1,216 @@
+---
+title: Filepicker Component
+component: x-bladewind::filepicker
+url: /component/filepicker
+---
+
+# Filepicker
+
+A wrapper around the popular [Filepond](https://pqina.nl/filepond/) file picker by PQINA. Supports drag-and-drop and click-to-browse. Includes image preview, cropping, resizing, automatic and manual uploads, base64 encoding, and multiple file selection.
+
+## Basic Usage
+
+```blade
+<x-bladewind::filepicker />
+
+{{-- with a name (required for manual uploads and base64) --}}
+<x-bladewind::filepicker name="certs" />
+```
+
+## Placeholder
+
+The default placeholder shows "Browse or drag and drop files" with accepted file types and max size on the second line. Customise with `placeholder_line1` and `placeholder_line2`.
+
+```blade
+<x-bladewind::filepicker
+    placeholder_line1="Upload proof of payment"
+    placeholder_line2="Only PDF files are allowed" />
+
+{{-- use %s to dynamically inject accepted_file_types and max_file_size --}}
+<x-bladewind::filepicker
+    placeholder_line1="Drag and drop proof of payment here"
+    placeholder_line2="Files allowed: %s up to %s" />
+```
+
+For a fully custom placeholder layout, define a hidden `div` with class `placeholder-[$name]` before the filepicker:
+
+```blade
+<div class="placeholder-invoices hidden flex space-y-2 align-middle py-3">
+    <x-bladewind::icon name="receipt-percent" class="!size-14 rounded-full p-3 bg-purple-400 text-purple-100"/>
+    <div class="text-left pl-2.5 pt-1.5">
+        <div>Drag & Drop Invoices</div>
+        <div class="!text-xs opacity-70"><u>PDFs</u> only. Max of <u>10mb</u></div>
+    </div>
+</div>
+<x-bladewind::filepicker name="invoices" />
+```
+
+## Drag-and-Drop or Browse Only
+
+```blade
+{{-- drag and drop only --}}
+<x-bladewind::filepicker can_browse="false" placeholder_line1="Drag and drop files" />
+
+{{-- browse only --}}
+<x-bladewind::filepicker can_drop="false" placeholder_line1="Click here to select your file" />
+```
+
+## File Size Limits
+
+```blade
+<x-bladewind::filepicker max_file_size="15kb" />
+
+{{-- total size limit across all selected files --}}
+<x-bladewind::filepicker max_files="3" max_total_file_size="30kb" />
+```
+
+## File Type Restrictions
+
+```blade
+<x-bladewind::filepicker accepted_file_types="application/pdf, .doc, .docx" />
+```
+
+## Multiple Files
+
+```blade
+<x-bladewind::filepicker max_files="5" />
+```
+
+## Image Manipulation
+
+```blade
+{{-- disable image preview --}}
+<x-bladewind::filepicker max_files="3" show_image_preview="false" />
+
+{{-- enable cropping --}}
+<x-bladewind::filepicker can_crop="true" />
+
+{{-- cropping with aspect ratio --}}
+<x-bladewind::filepicker can_crop="true" crop_aspect_ratio="4:3" />
+
+{{-- resize in background before upload --}}
+<x-bladewind::filepicker can_resize_image="true" image_resize_width="1024" />
+```
+
+Available `crop_aspect_ratio` values: `16:9` `4:3` `2:3` `1:1` `free`
+
+## Automatic Upload
+
+```blade
+<x-bladewind::filepicker
+    name="auto_upload"
+    auto_upload="true"
+    upload_route="/upload"
+    :upload_headers="$headers"
+    delete_route="/upload-delete"
+    max_file_size="1mb" />
+```
+
+The upload route receives a POST request. The delete route is called when a user removes an uploaded file, also via POST. The component passes `{ "path": "path/to/file" }` when deleting.
+
+```php
+// web.php
+Route::post('/upload', [FileUploadController::class, 'upload']);
+Route::post('/upload-delete', [FileUploadController::class, 'delete']);
+```
+
+## Manual Upload (Form Submission)
+
+Manual upload is the default. Use an array name for multiple files. Add `enctype="multipart/form-data"` to the form.
+
+```blade
+<form method="POST" action="/manual-upload" enctype="multipart/form-data">
+    @csrf
+    <x-bladewind::filepicker name="manual_upload[]" max_file_size="1mb" max_files="3" />
+    <x-bladewind::button can_submit="true">Upload Files</x-bladewind::button>
+</form>
+```
+
+## Base64 Encoding
+
+```blade
+<x-bladewind::filepicker name="attachments" base64="true" max_files="3" />
+```
+
+The base64 data is written to an input named `attachments_b64`. Use `base64_output="string"` or `base64_output="url"` (default) to control the format.
+
+## Edit Mode (Preloading Files)
+
+```blade
+@php
+$existingFiles = [
+    [ 'source' => asset('images/photo1.jpg') ],
+    [ 'source' => asset('images/photo2.jpg') ],
+];
+@endphp
+
+<x-bladewind::filepicker name="edit" max_files="2" :selected_value="$existingFiles" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | random | Name for the file input field |
+| accepted_file_types | image/\*, audio/\*, video/\*, application/pdf | MIME types or file extensions (comma-separated) |
+| placeholder_line1 | Choose files or drag and drop to upload | First line of placeholder text |
+| placeholder_line2 | %s up to %s | Second line of placeholder text. `%s` is replaced with file types and max size |
+| selected_value | [] | Array of `{ source: url }` objects to preload in edit mode |
+| required | false | Append asterisk to placeholder. `true` \| `false` |
+| can_browse | true | Allow click-to-browse. `true` \| `false` |
+| can_drop | true | Allow drag-and-drop. `true` \| `false` |
+| disabled | false | Disable the filepicker. `true` \| `false` |
+| max_files | 1 | Maximum number of files the user can select |
+| max_file_size | 5mb | Max size per file (include unit: `kb`, `mb`, `gb`) |
+| max_total_file_size | null | Max total size across all selected files |
+| validate_file_size | true | Validate file sizes. `true` \| `false` |
+| add_new_files_to | top | Where to insert newly added files. `top` \| `bottom` |
+| auto_upload | false | Automatically upload on selection. `true` \| `false` |
+| upload_route | null | URL for automatic uploads (POST) |
+| upload_method | POST | HTTP method for uploads. `POST` \| `PUT` \| `PATCH` |
+| upload_headers | [] | HTTP headers for upload requests |
+| delete_route | null | URL for deletion of uploaded files |
+| delete_method | null | HTTP method for deletion. Defaults to `upload_method` |
+| delete_headers | null | HTTP headers for delete requests. Defaults to `upload_headers` |
+| show_image_preview | true | Show image previews. `true` \| `false` |
+| can_crop | false | Enable image cropping. `true` \| `false` |
+| crop_aspect_ratio | 16:9 | Cropping aspect ratio. `16:9` \| `4:3` \| `2:3` \| `1:1` \| `free` |
+| can_resize_image | false | Resize image before upload (no UI). `true` \| `false` |
+| image_resize_width | null | Target width for resizing |
+| image_resize_height | null | Target height for resizing |
+| base64 | false | Generate base64 versions of selected files. `true` \| `false` |
+| base64_output | url | Format of base64 output. `url` \| `string` |
+| show_credits | false | Show Filepond credits. `true` \| `false` |
+| nonce | null | Nonce value for Content Security Policy |
+
+## Full Example
+
+```blade
+<x-bladewind::filepicker
+    name="profile_pic"
+    required="false"
+    placeholder_line1="Choose a profile picture"
+    placeholder_line2="Only jpg files allowed"
+    accepted_file_types=".jpg, .png"
+    disabled="false"
+    base64="false"
+    base64_output="string"
+    can_crop="false"
+    can_drop="true"
+    can_browse="true"
+    validate_file_size="true"
+    auto_upload="true"
+    max_files="2"
+    max_file_size="1mb"
+    max_total_file_size="2mb"
+    add_new_files_to="bottom"
+    show_image_preview="true"
+    can_resize_image="true"
+    image_resize_width="1024"
+    upload_route="/dp/upload"
+    upload_method="PATCH"
+    :upload_headers="$headers"
+    delete_route="/dp/delete"
+    delete_method="DELETE"
+    :delete_headers="$headers" />
+```

--- a/mcp/horizontal-line-graph.md
+++ b/mcp/horizontal-line-graph.md
@@ -1,0 +1,81 @@
+---
+title: Horizontal Line Graph Component
+component: x-bladewind::horizontal-line-graph
+url: /component/horizontal-line-graph
+---
+
+# Horizontal Line Graph
+
+Displays a labelled horizontal bar filled to a given percentage. Structurally similar to — and rendered using — the [Progress Bar](/component/progress-bar) component. The default colour is blue.
+
+## Basic Usage
+
+```blade
+<x-bladewind::horizontal-line-graph
+    label="Women Farmers: "
+    percentage="55.8" />
+```
+
+## Practical Example
+
+```blade
+<div class="grid grid-cols-2 gap-6">
+    <x-bladewind::card title="Mobile Money Penetration">
+        <x-bladewind::horizontal-line-graph label="MTN: " percentage="55" color="yellow" />
+        <x-bladewind::horizontal-line-graph label="Vodafone: " percentage="30" color="red" class="py-3" />
+        <x-bladewind::horizontal-line-graph label="AirtelTigo: " percentage="15" color="blue" />
+    </x-bladewind::card>
+
+    <x-bladewind::card title="Farmer age ratio">
+        <x-bladewind::horizontal-line-graph label="Above 60: " percentage="33" color="cyan" />
+        <x-bladewind::horizontal-line-graph label="Between 40 - 60: " percentage="43" color="purple" class="py-3" />
+        <x-bladewind::horizontal-line-graph label="Under 40: " percentage="24" color="gray" />
+    </x-bladewind::card>
+</div>
+```
+
+## Colours
+
+Set `color` to any supported colour. Two shades are available via `shade`: `faint` (default) and `dark`.
+
+```blade
+{{-- faint shades --}}
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="40" color="red" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="50" color="yellow" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="60" color="green" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="70" color="pink" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="80" color="cyan" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="30" color="gray" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="45" color="purple" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="55" color="orange" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="65" color="violet" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="75" color="indigo" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="85" color="fuchsia" />
+
+{{-- dark shades --}}
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="40" color="red" shade="dark" />
+<x-bladewind::horizontal-line-graph label="Women Farmers: " percentage="50" color="cyan" shade="dark" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| percentage | 0 | Fill percentage: any value between 0 and 100 |
+| label | _(blank)_ | Label displayed above the bar |
+| color | primary | Bar colour: `primary` `red` `yellow` `green` `blue` `pink` `cyan` `purple` `gray` `orange` `violet` `indigo` `fuchsia` |
+| shade | faint | Colour shade: `faint` \| `dark` |
+| percentage_label_opacity | 50 | Opacity of the percentage label (TailwindCSS opacity value without the `opacity-` prefix) |
+| class | bw-horizontal-line-graph | Additional CSS classes |
+
+## Full Example
+
+```blade
+<x-bladewind::horizontal-line-graph
+    label="Women Farmers: "
+    percentage="50"
+    color="red"
+    shade="faint"
+    percentage_label_opacity="75"
+    class="py-4" />
+```

--- a/mcp/icon.md
+++ b/mcp/icon.md
@@ -1,0 +1,110 @@
+---
+title: Icon Component
+component: x-bladewind::icon
+url: /component/icon
+---
+
+# Icon
+
+Display icons from [Heroicons](https://heroicons.com) or SVG files. Both solid and outline modes are supported when using icons from Heroicons. The default are outline icons. To display an icon from Heroicons, you will need to enter its name exactly as it is defined on the website.
+
+By default this component sets all icons at `h-6` and `w-6`. You can override the icon size and colours using the standard TailwindCSS classes. You can in fact, add any TailwindCSS class to the icon.
+
+```blade
+<x-bladewind::icon name="swatch" />
+```
+
+```blade
+<x-bladewind::icon
+    name="video-camera-slash" class="!h-16 !w-16 text-amber-500" />
+```
+
+```blade
+<x-bladewind::icon
+    name="microphone"
+    class="!h-14 !w-14 !text-white bg-pink-400 p-4 rounded-full
+            cursor-pointer hover:bg-pink-500 hover:p-3" />
+```
+
+```blade
+<x-bladewind::icon
+    name="speaker-wave"
+    class="!h-14 !w-14 text-cyan-500 p-3 animate-bounce rounded-md
+            cursor-pointer bg-white border-2 border-cyan-500
+            hover:bg-cyan-500 hover:text-white" />
+```
+
+## Solid Icons
+
+Icons from Heroicons come in two versions, outline and solid. The BladewindUI Icon component by default uses `outline` versions of the icons. To display solid versions of your icons, you will need to specify the attribute `type="solid"`.
+
+```blade
+<x-bladewind::icon name="swatch" type="solid" />
+```
+
+```blade
+<x-bladewind::icon
+    name="video-camera-slash"
+    type="solid"
+    class="!h-16 !w-16 text-amber-500" />
+```
+
+### SVG Icons
+
+So far all our icons have been from Heroicons. What if you have your own SVG icon tags from other websites you want to use? It is possible. Just paste the SVG tag in the `name` attribute of the icon and Bladewind will display it.
+
+Note how the name attribute now uses single quotes and not double quotes.
+
+```blade
+<x-bladewind::icon name='<svg class="h-24 w-24 inline-block dark:!fill-dark-100" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.72 9.56H5.78..." stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>' />
+```
+
+### SVG Image Files
+
+BladewindUI serves all the Heroicon icons from `public > vendor > bladewind > icons > [solid, outline]`. As stated earlier, the default icons served are outlines, so the _outline_ directory is used. When you specify `type="solid"`, the _solid_ directory is used. You can place your own SVG files in either the outline or solid directories and then enter the file name (without .svg) in the name attribute of the component.
+
+```blade
+<x-bladewind::icon name="discount-shape"
+    class="!h-24 !w-24 !fill-yellow-500 !stroke-yellow-300" />
+```
+
+```blade
+<x-bladewind::icon
+    name="message-notif"
+    type="solid"
+    class="!h-24 !w-24 !fill-green-300 !stroke-green-500" />
+```
+
+## Custom SVG Directory
+
+If you place your icon files in the default BladewindUI directory specified above, it is likely your files will be overwritten anytime there is a Bladewind update and you publish the public files. To ensure you don't lose your custom icons, it is advised you place them in a directory in your `public` directory. You will need to specify the `dir` attribute.
+
+Some TailwindCSS classes may not work on SVG files/icons that are not from Heroicons. SVG [fill](https://tailwindcss.com/docs/fill) and [stroke](https://tailwindcss.com/docs/stroke) classes were not working as expected in some cases.
+
+```blade
+<x-bladewind::icon
+    name="discount-circle"
+    dir="assets/images"
+    class="h-24 w-24" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | _(blank)_ | The name of the icon (as defined on [Heroicons](https://heroicons.com)) to display. |
+| type | outline | Determines what type of the icon to display. `outline` \| `solid` |
+| dir | _(blank)_ | Path within the `public` directory to a custom SVG file directory. |
+| class | h-6 w-6 inline-block | CSS classes for styling the icon. Accepts any [TailwindCSS](https://tailwindcss.com) classes applicable to SVGs. |
+
+## Full Example
+
+```blade
+<x-bladewind::icon
+    name="video-camera-slash"
+    type="solid"
+    dir="assets/images"
+    class="h-16 w-16 text-amber-500" />
+```

--- a/mcp/index.md
+++ b/mcp/index.md
@@ -1,0 +1,56 @@
+---
+title: BladewindUI Component Index
+url: /components
+---
+
+# BladewindUI Components
+
+BladewindUI is a collection of Laravel Blade components. Each file in this directory documents one component with its usage, examples, and full attribute reference.
+
+## Component List
+
+| Component | Tag | File |
+|---|---|---|
+| Accordion | `x-bladewind::accordion` | [accordion.md](accordion.md) |
+| Alert | `x-bladewind::alert` | [alert.md](alert.md) |
+| Avatar | `x-bladewind::avatar` | [avatar.md](avatar.md) |
+| Bell | `x-bladewind::bell` | [bell.md](bell.md) |
+| Button | `x-bladewind::button` | [button.md](button.md) |
+| Calendar | `x-bladewind::calendar` | [calendar.md](calendar.md) |
+| Card | `x-bladewind::card` | [card.md](card.md) |
+| Centered Content | `x-bladewind::centered-content` | [centered-content.md](centered-content.md) |
+| Chart | `x-bladewind::chart` | [chart.md](chart.md) |
+| Checkbox | `x-bladewind::checkbox` | [checkbox.md](checkbox.md) |
+| Check Card | `x-bladewind::checkcard` | [checkcard.md](checkcard.md) |
+| Color Picker | `x-bladewind::colorpicker` | [colorpicker.md](colorpicker.md) |
+| Date Picker | `x-bladewind::datepicker` | [datepicker.md](datepicker.md) |
+| Drop Menu | `x-bladewind::dropmenu` | [dropmenu.md](dropmenu.md) |
+| Empty State | `x-bladewind::empty-state` | [empty-state.md](empty-state.md) |
+| Filepicker | `x-bladewind::filepicker` | [filepicker.md](filepicker.md) |
+| Horizontal Line Graph | `x-bladewind::horizontal-line-graph` | [horizontal-line-graph.md](horizontal-line-graph.md) |
+| Icon | `x-bladewind::icon` | [icon.md](icon.md) |
+| Input | `x-bladewind::input` | [input.md](input.md) |
+| List View | `x-bladewind::list-view` | [list-view.md](list-view.md) |
+| Modal | `x-bladewind::modal` | [modal.md](modal.md) |
+| Notification | `x-bladewind::notification` | [notification.md](notification.md) |
+| Number | `x-bladewind::number` | [number.md](number.md) |
+| Process Indicator | `x-bladewind::processing` | [process-indicator.md](process-indicator.md) |
+| Progress Bar | `x-bladewind::progress-bar` | [progress-bar.md](progress-bar.md) |
+| Progress Circle | `x-bladewind::progress-circle` | [progress-circle.md](progress-circle.md) |
+| Radio Button | `x-bladewind::radio-button` | [radio-button.md](radio-button.md) |
+| Rating | `x-bladewind::rating` | [rating.md](rating.md) |
+| Select | `x-bladewind::select` | [select.md](select.md) |
+| Shimmer | `x-bladewind::shimmer` | [shimmer.md](shimmer.md) |
+| Slider | `x-bladewind::slider` | [slider.md](slider.md) |
+| Spinner | `x-bladewind::spinner` | [spinner.md](spinner.md) |
+| Statistic | `x-bladewind::statistic` | [statistic.md](statistic.md) |
+| Tab | `x-bladewind::tab` | [tab.md](tab.md) |
+| Table | `x-bladewind::table` | [table.md](table.md) |
+| Tag | `x-bladewind::tag` | [tag.md](tag.md) |
+| Textarea | `x-bladewind::textarea` | [textarea.md](textarea.md) |
+| Theme Switcher | `x-bladewind::theme-switcher` | [theme-switcher.md](theme-switcher.md) |
+| Timeline | `x-bladewind::timeline` | [timeline.md](timeline.md) |
+| Timepicker | `x-bladewind::timepicker` | [timepicker.md](timepicker.md) |
+| Toggle | `x-bladewind::toggle` | [toggle.md](toggle.md) |
+| Tooltip | `x-bladewind::tooltip` | [tooltip.md](tooltip.md) |
+| Verification Code | `x-bladewind::verification-code` | [verification-code.md](verification-code.md) |

--- a/mcp/input.md
+++ b/mcp/input.md
@@ -1,0 +1,414 @@
+---
+title: Input Component
+component: x-bladewind::input
+url: /component/input
+---
+
+# Input
+
+Displays a text input element. This is also commonly known as a text box. This component works for all the possible values of `<input type="" .../>`. The default is `input type="text"`. This Bladewind component simply wraps the HTML input so you are free to use all the various [input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes) available in HTML.
+
+```blade
+<x-bladewind::input />
+```
+
+## Password Input
+
+This behaves just like the regular HTML password input. Nothing fancy. Any values entered into this field are masked.
+
+```blade
+<x-bladewind::input type="password" />
+```
+
+### Reveal Passwords
+
+The component allows you to specify if the user should be able to view the password they entered by clicking on an eye. This can be achieved by setting `viewable="true"`. The eye is appended as a suffix to the input. Clicking on the eye when the password is revealed, hides the password. The eye icon will be displayed ONLY if the input `type="password"`. It will be ignored in all other cases.
+
+```blade
+<x-bladewind::input type="password" viewable="true" />
+```
+
+## Numeric Input
+
+This accepts only numeric values. Useful when entering phone numbers, age or amounts. By default the decimal point is not allowed as it is technically not a number. In cases where you need decimals, use the attribute `with_dots="true"`.
+
+```blade
+<x-bladewind::input numeric="true" />
+```
+
+### Minimum & Maximum Values
+
+You may want users to enter a minimum or maximum number when using the numeric input. For example, let's say employees cannot request more than 5 days off per leave request. Your input could restrict the maximum number of days off to 5 when a user is filling the form.
+
+```blade
+<x-bladewind::input
+    placeholder="Minimum is 3"
+    name="input-min"
+    numeric="true"
+    min="3"
+    error_message="Minimum value must be 3"
+    show_error_inline="true" />
+```
+
+```blade
+<x-bladewind::input
+    placeholder="Maximum is 12"
+    name="input-max"
+    numeric="true"
+    max="12"
+    error_message="Maximum value must be 12" />
+```
+
+## Inputs With Labels
+
+You can display the BladewindUI textbox with labels. Labels present themselves as placeholders but jump to the top border of the textbox when that field has focus. This is a nice way to build compact looking forms without having form labels in the way. If you prefer to create and style your own form labels, simply ignore the `label` attribute and use the `placeholder` attribute instead.
+
+```blade
+<x-bladewind::input label="Full name" />
+```
+
+### Placeholder Text
+
+```blade
+<x-bladewind::input placeholder="Full name" />
+```
+
+### What Happens When Both Placeholder and Label are Set
+
+The `label` attribute actually replaces `placeholder`. In most common cases input labels are displayed above the input box and don't interfere with the input's placeholder text. However, the label for Bladewind's Textbox component is designed to sit in the same spot where the placeholder text is displayed and covers it up. Having a placeholder text that is longer than your label text results in some parts of the placeholder text sticking out under the label. If you want the placeholder to still be shown even when there is a label, set `show_placeholder_always="true"`.
+
+```blade
+<x-bladewind::input
+    name="mobile" label="Mobile" placeholder="000.0000.000" />
+```
+
+## Required Fields
+
+This either adds a red asterisk sign to the placeholder text or a red star to the label of the input field.
+
+```blade
+<x-bladewind::input required="true" label="Full name" />
+```
+
+## Events
+
+You can append any of the available HTML event attributes (_onclick, onblur, onfocus, onmouseover, onmouseout, onkeyup, onkeydown_ etc) to the component, just like you would to a regular `<input ...` tag.
+
+```blade
+<x-bladewind::input
+    name="events"
+    label="Full name"
+    required="true"
+    onfocus="changeCss('.events', '!border-2,!border-red-400')"
+    onblur="changeCss('.events', '!border-2,!border-red-400', 'remove')" />
+```
+
+### Validating Required Fields
+
+Bladewind comes with a very handy Javascript helper function (`validateForm(element)`) for validating input and textarea fields that have the attribute `required='true"` set. Error messages can either be displayed inline or using the [Bladewind notification](/component/notification) component.
+
+The `error_message` attribute defines what will be displayed if the field is empty when the form is validated. The `show_error_inline="true"` attribute will display the error message beneath the field it was set on.
+
+```blade
+<x-bladewind::notification />
+
+<x-bladewind::card>
+    <form method="get" class="signup-form">
+        <x-bladewind::input
+            name="fname"
+            required="true"
+            label="Full Name"
+            error_message="You will need to enter your full name" />
+
+        <div class="flex gap-4">
+            <x-bladewind::input
+                name="email"
+                required="true"
+                label="Email" />
+
+            <x-bladewind::input
+                name="mobile"
+                label="Mobile"
+                numeric="true" />
+        </div>
+
+        <x-bladewind::textarea
+            required="true"
+            name="bio"
+            error_message="Yoh! write something nice about yourself"
+            show_error_inline="true"
+            label="Describe yourself"></x-bladewind::textarea>
+
+        <div class="text-center">
+            <x-bladewind::button
+                name="btn-save"
+                has_spinner="true"
+                type="primary"
+                can_submit="true"
+                class="mt-3">
+                Sign Up Today
+            </x-bladewind::button>
+        </div>
+    </form>
+</x-bladewind::card>
+```
+
+## JavaScript
+
+```js
+// domEl, unhide and hide are helper functions in BladewindUI
+domEl('.signup-form').addEventListener('submit', function (e){
+    e.preventDefault();
+    signUp();
+});
+
+signUp = () => {
+    (validateForm('.signup-form')) ?
+        unhide('.btn-save .bw-spinner') :
+        hide('.btn-save .bw-spinner');
+}
+```
+
+## Manipulating Inputs Using Javascript
+
+There are several instances where you will want to manipulate input fields for different reasons. Most times, manipulating an input field will be dependent on a user's selection. This can be achieved in Javascript since BladewindUI uses the `name` attribute defined on an input as part of its `class` attribute.
+
+The name you provided to the Input component has been used as part of the `class` names of the component. This makes it easy for you to access the component in Javascript.
+
+```blade
+<div class="flex gap-4">
+    <x-bladewind::input name="full_name" required="true" label="Full name" />
+    <x-bladewind::input name="age_camp" label="How old are you?"
+        required="true" numeric="true" with_dots="true" />
+</div>
+<b class="guardian-info py-2 block hidden">Who is your guardian?</b>
+<div class="guardian flex gap-4 hidden">
+    <x-bladewind::input name="guardian_name_camp" required="true" label="Guardian's Name" />
+    <x-bladewind::input name="guardian_email_camp"
+        label="Guardian's email"
+        onkeyup="showAddress(this.value)" />
+</div>
+<x-bladewind::input name="guardian_address" placeholder="Guardian's address" class="hidden" />
+```
+
+```js
+// domEl, unhide and hide are helper functions in BladewindUI
+domEl('.age_camp').addEventListener('keyup', (el) => {
+    if(el.target.value !== ''  && el.target.value < 18 ){
+        unhide('.guardian-info');
+        unhide('.guardian');
+    } else {
+        hide('.guardian-info');
+        hide('.guardian');
+    }
+})
+
+showAddress = (value) => {
+    if(value !== '') unhide('.guardian_address');
+}
+```
+
+To manipulate BladewindUI input elements using Javascript, simply target them using the name defined either in the class or id attributes.
+
+## Prefixes and Suffixes
+
+There are cases where you need to prefix or append something to an input field. For example, you want to prefix a URL input field with 'https://' so your users wouldn't need to type that in every time. Or, when asking your app users for their social media handles you may want to always have the '@' prefix. For now prefixes and suffixes support only text and [icons](/component/icon).
+
+### Prefixes
+
+You can use prefixes even when your input has a label.
+
+```blade
+<x-bladewind::input name="site" label="website address" prefix="https://" />
+```
+
+```blade
+<x-bladewind::input name="site2" placeholder="website address" prefix="https://" />
+```
+
+```blade
+<x-bladewind::input name="usd" placeholder="0.00" prefix="USD" />
+```
+
+```blade
+<x-bladewind::input name="twitter" placeholder="Twitter handle" prefix="@" />
+```
+
+```blade
+<x-bladewind::input name="gh" placeholder="username" prefix="https://github.com/" />
+```
+
+### Suffixes
+
+Suffixes get appended to the end of the input field.
+
+```blade
+<x-bladewind::input name="space" placeholder="workspace-name" suffix=".slack.com" />
+```
+
+```blade
+<x-bladewind::input
+    name="tnc"
+    placeholder="Your bio. Keep it brief and nice"
+    suffix='<a href="#">See some good examples</a>' />
+```
+
+### Prefix and Suffix Transparency
+
+You can opt for non-transparent prefixes and suffixes by setting the attribute `transparent_prefix="false"` and/or `transparent_suffix="false"`. You can specify both a prefix and suffix on your input fields.
+
+```blade
+<x-bladewind::input
+    name="usdbg"
+    placeholder="0.00"
+    prefix="USD"
+    transparent_prefix="false"
+    numeric />
+```
+
+```blade
+<x-bladewind::input
+    name="spacex"
+    placeholder="workspace-name"
+    transparent_suffix="false"
+    suffix=".slack.com" />
+```
+
+```blade
+<x-bladewind::input
+    name="spacexx"
+    prefix="https://"
+    transparent_prefix="false"
+    placeholder="workspace-name"
+    suffix=".slack.com"
+    transparent_suffix="false" />
+```
+
+## Inputs With Icons
+
+The BladewindUI input field can have an icon for those moments where you want a simple icon to describe the field. This is not a different kind of input field. We simply make use of prefixes and suffixes to achieve this effect. All [Heroicons](https://heroicons.com) names are supported out of the box. You can also specify an SVG tag to be used as an icon.
+
+Since input icons are achieved using prefixes, it is important to add the attribute `prefix_is_icon="true"` if you are using icons as prefixes or `suffix_is_icon="true"` if you are using icons as suffixes. This way Bladewind forces your prefix or suffix to be an icon and not text.
+
+```blade
+<x-bladewind::input
+    name="fullname"
+    placeholder="John T. Doe"
+    prefix="user"
+    prefix_is_icon="true" />
+
+<x-bladewind::input
+    name="emailic"
+    placeholder="me@bladewindui.com"
+    prefix="envelope"
+    prefix_is_icon="true" />
+
+<x-bladewind::input
+    name="fon"
+    placeholder="0000.000.00"
+    prefix="phone"
+    prefix_is_icon="true" />
+
+<x-bladewind::input
+    name="passw" type="password"
+    placeholder="Password"
+    prefix="key"
+    prefix_is_icon="true"
+    prefix_icon_css="text-orange-500"
+    viewable="true" />
+```
+
+## Clearable Inputs
+
+Clearable fields display an x icon when a field has a value entered. Clicking on the x icon deletes the text in the input field. Quite handy and saves users from clicking the backspace several times in say, a search field. This is achieved by setting the `clearable="true"` attribute. If there is a table that shares the same name as the input field, it will be reset as well.
+
+```blade
+<x-bladewind::input placeholder="I am clearable" clearable />
+```
+
+## Input Field Sizes
+
+The input field comes in sizes to match the various button sizes. This is useful if you wish to have an input field and a button on one line. Set the `size` attribute to achieve this. The `tiny` size is not supported for input fields.
+
+```blade
+<x-bladewind::input label="I am small" size="small" />
+```
+
+```blade
+<x-bladewind::input label="I am regular" />
+```
+
+```blade
+<x-bladewind::input label="I am medium" size="medium" />
+```
+
+```blade
+<x-bladewind::input label="I am big" size="big" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | input-uniqid() | Unique name to identify the input element by. Useful for retrieving value from the input when it is submitted in a form. |
+| type | text | Accepts list of valid HTML input element types. `text` \| `email` \| `password` \| `search` \| `tel` |
+| label | _(blank)_ | Label that describes the input element. Example: Full name |
+| numeric | false | Specifies if the input element should accept only numeric characters. `true` \| `false` |
+| required | false | Specifies if the input element is required or not. When required, a red asterisk is displayed next to the placeholder or label. `true` \| `false` |
+| add_clearing | true | Specifies if an 8px margin should be added to the bottom of the element. `true` \| `false` |
+| placeholder | _(blank)_ | Placeholder text to display in the input element. |
+| show_placeholder_always | false | Placeholder text is hidden when the label attribute has a value. Setting this to true always shows the placeholder. `true` \| `false` |
+| error_message | _(blank)_ | The message to display when the form is validated and field happens to be blank. |
+| show_error_inline | false | Error messages can either be displayed inline or using the Notification component (default). `true` \| `false` |
+| error_heading | Error | Only used when displaying validation errors using the Notification component. Provides a way to specify a translatable heading for the error. |
+| selected_value | _(blank)_ | Default value to display in the input element. Useful when in edit mode. |
+| with_dots | true | Mostly relevant if `numeric="true"`. Determines if numeric values can contain dots or not. `true` \| `false` |
+| prefix | blank | Specify the prefix for the input field. |
+| prefix_is_icon | false | If prefix is specified, is it an icon. By default prefixes are treated as text. `true` \| `false` |
+| prefix_icon_type | outline | If an icon is used as a prefix, should it be a solid or outline icon. `outline` \| `solid` |
+| transparent_prefix | true | If a prefix is defined, should it have a transparent background or not. `true` \| `false` |
+| prefix_icon_div_css | blank | Additional css classes to apply to the DIV containing the prefix if **prefix_is_icon=true**. |
+| prefix_icon_css | blank | Additional css classes to apply to the prefix if **prefix_is_icon=true**. |
+| suffix | blank | Specify the suffix for the input field. |
+| suffix_is_icon | false | If suffix is specified, is it an icon. By default suffixes are treated as text. `true` \| `false` |
+| suffix_icon_type | outline | If an icon is used as a suffix, should it be a solid or outline icon. `outline` \| `solid` |
+| transparent_suffix | true | If a suffix is defined, should it have a transparent background or not. `true` \| `false` |
+| suffix_icon_div_css | blank | Additional css classes to apply to the DIV containing the suffix if **suffix_is_icon=true**. |
+| suffix_icon_css | blank | Additional css classes to apply to the suffix if **suffix_is_icon=true**. |
+| viewable | false | Works only if **type=password**. Should the password be viewable? If `true`, an eye icon is displayed. `true` \| `false` |
+| clearable | false | Appends an 'x' circle for clearing any text that has been entered in the input field. `true` \| `false` |
+| size | medium | Sizing of the input to match button sizes. `small` \| `regular` \| `medium` \| `big` |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. |
+
+## Full Example
+
+```blade
+<x-bladewind::input
+    name="pin"
+    label="Enter PIN"
+    placeholder=""
+    type="password"
+    numeric="false"
+    add_clearing="false"
+    required="true"
+    error_message="PIN can only be 4 digits"
+    show_error_inline="true"
+    error_heading="Bugged"
+    with_dots="true"
+    show_placeholder_always="true"
+    selected_value=""
+    size="medium"
+    prefix="Email"
+    transparent_prefix="false"
+    prefix_is_icon="false"
+    prefix_icon_type="solid"
+    prefix_icon_css=""
+    suffix="@gmail.com"
+    transparent_suffix="false"
+    suffix_is_icon="false"
+    suffix_icon_type="solid"
+    suffix_icon_css=""
+    viewable="false"
+    clearable="false"
+/>
+```

--- a/mcp/list-view.md
+++ b/mcp/list-view.md
@@ -1,0 +1,95 @@
+---
+title: List View Component
+component: x-bladewind::listview
+url: /component/list-view
+---
+
+# List View
+
+Display a list of items. The list view component mimicks the `<ul><li>...</li></ul>` tags. The component makes use of two tags to render the list of items. Just like when using a `<li></li>`, the user is completely in charge of what content goes in there. All the list view component does is draw fine lines between your items. Every top level block element is flexed into its own column. The first top level block element has no left padding so you'll need to factor that into your design when using this component.
+
+The `<x-bladewind::listview.item>` component creates a flex container.
+
+```blade
+<x-bladewind::card no-padding="true">
+    <x-bladewind::listview compact="true">
+        <x-bladewind::listview.item>
+            <x-bladewind::avatar size="small" image="/assets/images/me.jpeg" />
+            <div>
+                <div class="text-sm font-medium text-slate-900 dark:text-slate-200">Michael K. Ocansey</div>
+                <div class="text-sm text-slate-500 truncate">mike@bladewindui.com</div>
+            </div>
+        </x-bladewind::listview.item>
+        <x-bladewind::listview.item>
+            <x-bladewind::avatar size="small" image="AJ" bg_color="orange" />
+            <div>
+                <div class="text-sm font-medium text-slate-900 dark:text-slate-200">Anonymous Jackson</div>
+                <div class="text-sm text-slate-500 truncate">fake@person.com</div>
+            </div>
+        </x-bladewind::listview.item>
+        <x-bladewind::listview.item>
+            <x-bladewind::avatar size="small" image="/assets/images/issah.jpg" />
+            <div>
+                <div class="text-sm font-medium text-slate-900 dark:text-slate-200">Catherine Gerald</div>
+                <div class="text-sm text-slate-500 truncate">kate.gee@gmail.com</div>
+            </div>
+        </x-bladewind::listview.item>
+    </x-bladewind::listview>
+</x-bladewind::card>
+```
+
+By default the list view component sits on a white background. You can remove this by setting the `transparent="true"` attribute. You can then set a different background colour using the `class` attribute.
+
+```blade
+<x-bladewind::listview transparent="true">
+
+    <x-bladewind::listview.item>
+
+        <x-bladewind::avatar
+            size="small"
+            image="/path/to/the/image/file" />
+        <div class="ml-3">
+            <div class="text-sm font-medium text-slate-900">
+                Michael K. Ocansey
+            </div>
+            <div class="text-sm text-slate-500 truncate">
+                kabutey@gmail.com
+            </div>
+        </div>
+
+    </x-bladewind::listview.item>
+    ...
+</x-bladewind::listview>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| transparent | false | Should the background of the component be transparent or placed on a white background. `true` \| `false` |
+| compact | false | If set to true, the spacing between the list items are reduced from 16px to 8px. `true` \| `false` |
+| class | _(blank)_ | Any additional css you wish to add. |
+
+## Full Example
+
+```blade
+<x-bladewind::listview compact="true" transparent="true" class="bg-yellow-50">
+
+    <x-bladewind::listview.item>
+
+        <x-bladewind::avatar
+            size="small"
+            image="/path/to/the/image/file" />
+        <div class="ml-3">
+            <div class="text-sm font-medium text-slate-900">
+                Michael K. Ocansey
+            </div>
+            <div class="text-sm text-slate-500 truncate">
+                kabutey@gmail.com
+            </div>
+        </div>
+
+    </x-bladewind::listview.item>
+    ...
+</x-bladewind::listview>
+```

--- a/mcp/modal.md
+++ b/mcp/modal.md
@@ -1,0 +1,592 @@
+---
+title: Modal Component
+component: x-bladewind::modal
+url: /component/modal
+---
+
+# Modal
+
+The modal component is useful for displaying content that is overlayed on the primary page content.
+
+## Default Modal
+
+Modals are mostly displayed when an action is triggered, say when a button is clicked. All BladewindUI modals are invoked via a javascript helper function bundled with the component: `showModal('name-of-modal');`. Like with all BladewindUI components, the syntax for cooking up a modal is very simple.
+
+> IMPORTANT: BladewindUI Modals are created, targeted and invoked using the `name` attribute. You can have several modals on the same page but it is very important to provide unique names for each modal.
+
+Clicking on the backdrop of the modal or on the cancel button will by default dismiss the modal. The `hideModal('name-of-modal');` helper function is called to dismiss modals. It is possible to prevent the backdrop or the cancel button from closing the modal. See the Non-dismissed modal section below.
+
+```blade
+<x-bladewind::button
+    show_close_icon="true"
+    onclick="showModal('tnc-agreement')">
+    Basic modal
+</x-bladewind::button>
+
+<x-bladewind::button
+    onclick="showModal('tnc-agreement-titled')">
+    Basic modal with a title
+</x-bladewind::button>
+
+<x-bladewind::modal
+    name="tnc-agreement">
+    Please agree to the terms and conditions of
+    the agreement before proceeding.
+</x-bladewind::modal>
+
+<x-bladewind::modal
+    name="tnc-agreement-titled"
+    title="Agree or Disagree">
+    Please agree to the terms and conditions of
+    the agreement before proceeding.
+</x-bladewind::modal>
+```
+
+## Different Types
+
+The BladewindUI modal component comes prebuilt with some default types for the common use cases. This can be achieved by setting the `type` attribute on the modal component. The default `type=""`. All the type attribute does is append the appropriate icons that match the type of modal.
+
+### Info Modal
+
+Set `type="info"` on the modal component. The default icon changes to a blue info icon.
+
+```blade
+<x-bladewind::button onclick="showModal('info')">
+    Info Modal
+</x-bladewind::button>
+
+<x-bladewind::modal
+    type="info"
+    title="General Info"
+    name="info">
+    We really think you should buy some Bitcoin
+    despite it's ups and downs. What sayeth thou?
+</x-bladewind::modal>
+```
+
+### Error Modal
+
+Set `type="error"` on the modal component. The default icon changes to a red exclamation mark.
+
+```blade
+<x-bladewind::button onclick="showModal('error')">
+    Error Modal
+</x-bladewind::button>
+
+<x-bladewind::modal
+    type="error"
+    title="Delete Not Allowed"
+    name="error">
+    You do not have permissions to delete this user.
+</x-bladewind::modal>
+```
+
+### Warning Modal
+
+Set `type="warning"` on the modal component. The default icon changes to a yellow bell icon.
+
+```blade
+<x-bladewind::button onclick="showModal('warning')">
+    Warning Modal
+</x-bladewind::button>
+
+<x-bladewind::modal
+    type="warning"
+    title="First warning"
+    name="warning">
+    Hmmm...This is your first warning.
+    Two more warnings and you are off this platform.
+</x-bladewind::modal>
+```
+
+### Success Modal
+
+Set `type="success"` on the modal component. The default icon changes to a green thumbs up icon.
+
+```blade
+<x-bladewind::button onclick="showModal('success')">
+    Success Modal
+</x-bladewind::button>
+
+<x-bladewind::modal
+    type="success"
+    title="User Deleted"
+    name="success">
+    Yayy.. User deleted successfully
+</x-bladewind::modal>
+```
+
+### Stretched Action Buttons
+
+Some users prefer to have their action buttons span the entire width of the modal. Set `stretched_action_buttons="true"` on the modal component.
+
+```blade
+<x-bladewind::button onclick="showModal('stretched')">
+    Stretched Buttons Modal
+</x-bladewind::button>
+
+<x-bladewind::modal
+    title="Stretched Buttons"
+    stretched_action_buttons="true"
+    name="stretched">
+    The action buttons in this modal have been stretched.
+    This means each button gets its own line.
+</x-bladewind::modal>
+```
+
+## Backdrop Blur Intensity
+
+The backdrop can be customized to have different intensities of the blur by specifying `blur_size`. The available values are `none`, `small`, `medium`, `large`, `xl`, `xxl`, `omg`.
+
+```blade
+<x-bladewind::button onclick="showModal('noblur')">
+    No Blur
+</x-bladewind::button>
+
+<x-bladewind::modal
+    title="See Through Me"
+    blur_size="none"
+    name="noblur">
+    The backdrop of this modal is not blurred.
+    You can see all the content behind the backdrop.
+</x-bladewind::modal>
+```
+
+## Using Different Icons
+
+The default types use predefined icons. You may want to use your own icons in the modal component. Set the `icon` attribute to any icon name on [Heroicons](https://heroicons.com). This modal icon is displayed using the BladewindUI [Icon](/component/icon) component. Use the `icon_css` attribute to apply extra styling to the custom icon.
+
+```blade
+<x-bladewind::button onclick="showModal('iconic')">
+    Custom Icon Modal
+</x-bladewind::button>
+
+<x-bladewind::modal
+    icon="folder-arrow-down"
+    icon_css="bg-gray-500 text-white p-2.5 rounded-full"
+    title="Large File Size"
+    name="info">
+    The file you are trying to download is very big.
+    Do you still want to continue with the download?
+</x-bladewind::modal>
+```
+
+You may want to use a custom icon but with one of the predefined states. Simply set both the `type` and `icon` attributes.
+
+```blade
+<x-bladewind::modal
+    title="Large File Size"
+    type="warning"
+    name="iconic-warning"
+    icon="folder-arrow-down">
+    The file you are trying to download is very big.
+    Do you still want to continue with the download?
+</x-bladewind::modal>
+```
+
+## Different Sizes
+
+> On mobile the modal has just one size.
+
+The BladewindUI modal component comes with a size option that allows your content to breathe in the modals. Set the `size` attribute on the modal component. The default `size="small"`. All sizes are the same on mobile.
+
+| Size | CSS Class |
+|---|---|
+| tiny | `sm:w-72` |
+| small | `sm:w-96` |
+| medium | `sm:w-[32rem]` |
+| large | `sm:w-[60rem]` |
+| xl | `sm:w-[86rem]` |
+| omg | `max-w-screen` |
+
+```blade
+<x-bladewind::modal
+    size="tiny"
+    title="Tiny Modal"
+    name="tiny-modal">
+    I am the tiniest in the modal family. Don't hate.
+</x-bladewind::modal>
+
+<x-bladewind::modal
+    size="small"
+    title="Small Modal"
+    name="small-modal">
+    I am the smallest in the modal family. Don't hate.
+</x-bladewind::modal>
+
+<x-bladewind::modal
+    title="Medium Modal"
+    size="medium"
+    name="medium-modal">
+    I am the medium sized modal.
+    Also the default if you do not set a size.
+</x-bladewind::modal>
+
+<x-bladewind::modal
+    size="large"
+    title="Large Modal"
+    name="large-modal">
+    I am the large modal. If I am not large enough to contain
+    your needs, check out my xl brother.
+</x-bladewind::modal>
+
+<x-bladewind::modal
+    size="xl"
+    title="XL Modal"
+    name="xl-modal">
+    I am the extra large modal.
+</x-bladewind::modal>
+
+<x-bladewind::modal
+    size="omg"
+    title="Full Width Modal"
+    name="omg-modal">
+    I am the full width modal. My nickname is OMG.
+</x-bladewind::modal>
+```
+
+## Action Buttons
+
+The modal component by default shows a `Cancel` and `Okay` button. Both buttons by default close the modal when clicked. It is possible to show either of the buttons or even none of the buttons.
+
+If you don't want your buttons to say **Cancel** and **Okay**, set the `cancel_button_label` and `ok_button_label` attributes to whatever text you want the buttons to display.
+
+To hide the `cancel` button, set `cancel_button_label=""`. When the button label is blank, the button won't be displayed. To hide the okay button, set `ok_button_label=""`.
+
+### No Cancel Button
+
+```blade
+<x-bladewind::button onclick="showModal('no-cancel')">
+    No cancel button
+</x-bladewind::button>
+
+<x-bladewind::modal
+    title="No Cancel Button"
+    name="no-cancel"
+    cancel_button_label="">
+    I have no cancel button. Just okay and that is fine.
+</x-bladewind::modal>
+```
+
+### No Okay Button
+
+```blade
+<x-bladewind::button onclick="showModal('no-okay')">
+    No okay button
+</x-bladewind::button>
+
+<x-bladewind::modal
+    title="No Okay Button"
+    name="no-okay"
+    ok_button_label="">
+    I have no okay button.
+    Just cancel this thing and let's all go home.
+</x-bladewind::modal>
+```
+
+### Hiding Both Action Buttons
+
+Set `show_action_buttons="false"` to hide both action buttons. A no-action-buttons modal can be useful if you want to have a form in a modal with its own button that submits the form.
+
+```blade
+<x-bladewind::button onclick="showModal('no-action-buttons')">
+    No action buttons
+</x-bladewind::button>
+
+<x-bladewind::modal
+    title="No Action Buttons"
+    name="no-action-buttons"
+    show_action_buttons="false">
+    I have no action buttons. Only the backdrop can close me now.
+</x-bladewind::modal>
+```
+
+### Action Button Actions
+
+By default both action buttons close the modal. To change these default actions, set the `cancel_button_action` and `ok_button_action` attributes. The default values are `cancel_button_action="close"` and `ok_button_action="close"`. The attributes expect javascript functions as the values.
+
+```blade
+<x-bladewind::modal
+    size="big"
+    type="warning"
+    title="Confirm User Deletion"
+    ok_button_action="alert('as you wish')"
+    cancel_button_action="alert('good choice')"
+    close_after_action="false"
+    name="custom-actions"
+    ok_button_label="Yes, delete"
+    cancel_button_label="don't delete">
+    Are you sure you want to delete this user? This action cannot be undone.
+</x-bladewind::modal>
+```
+
+By default, the modal is dismissed after clicking any of the action buttons. Setting `close_after_action="false"` will ensure the modal stays open after clicking any of the action buttons.
+
+### Close Icon
+
+To close a modal using a close icon placed in the top right, set `show_close_icon="true"`.
+
+### Alignment of the Action Buttons
+
+By default the action buttons are right aligned but left aligned if the modal `size="tiny"`. To change the alignment of the action buttons, set the `align_buttons` attribute to either `left`, `center` or `right`.
+
+## Non-Dismissible Modal
+
+By default the modal component can be closed using the backdrop or any of the action buttons. To prevent dismissal, set `backdrop_can_close="false"`. If you are using the modals with the action buttons you will also need to set the actions of each button.
+
+```blade
+<x-bladewind::modal
+    show_action_buttons="false"
+    backdrop_can_close="false"
+    name="lock-screen">
+
+    <div class="flex mx-auto justify-center my-2">
+        <x-bladewind.avatar class="" image="/path/to/the/image/file" />
+    </div>
+    <div class="my-4">
+        You will need to unlock the screen to continue using this application.
+    </div>
+
+    <x-bladewind.input
+        placeholder="Enter your password to unlock"
+        type="password" />
+
+    <x-bladewind::button class="w-full">Check password</x-bladewind::button>
+
+</x-bladewind::modal>
+```
+
+## Submitting Form Using Action Button
+
+### Validate and Submit Form
+
+```blade
+// the modal and its form
+<x-bladewind::modal
+    backdrop_can_close="false"
+    name="form-mode"
+    ok_button_action="saveProfile()"
+    ok_button_label="Update"
+    close_after_action="false"
+    >
+
+    <form method="post" action="" class="profile-form">
+        @csrf
+        <b class="mt-0">Edit Your Profile</b>
+        <div class="grid grid-cols-2 gap-4 mt-6">
+            <x-bladewind::input required="true" name="first_name"
+                error_message="Please enter your first name" label="First name" />
+
+            <x-bladewind::input required="true" name="last_name"
+                 error_message="Please enter your last name" label="Last name" />
+        </div>
+        <x-bladewind::input required="true" name="email"
+             error_message="Please enter your email" label="Email address" />
+
+        <x-bladewind::input numeric="true" name="mobile" label="Mobile" />
+    </form>
+
+</x-bladewind::modal>
+```
+
+## JavaScript
+
+```js
+// the script called by the Update button
+saveProfile = () => {
+    if(validateForm('.profile-form')){
+        domEl('.profile-form').submit();
+    } else {
+        return false;
+    }
+}
+```
+
+### Using Ajax
+
+The next example submits the form via Ajax and makes use of the [Process Indicator](/component/process-indicator) component to show progress.
+
+```blade
+<x-bladewind::modal
+    backdrop_can_close="false"
+    name="form-mode-ajax"
+    ok_button_action="saveProfileAjax()"
+    ok_button_label="Update"
+    close_after_action="false">
+
+    <form method="get" action="" class="profile-form-ajax">
+        @csrf
+        <b>Edit Your Profile</b>
+        <div class="grid grid-cols-2 gap-4 mt-6">
+            <x-bladewind::input required="true" name="first_name2"
+                label="First name" error_message="Please enter your first name" />
+            <x-bladewind::input required="true" name="last_name2"
+                label="Last name" error_message="Please enter your last name" />
+        </div>
+        <x-bladewind::input required="true" name="email2"
+                label="Email address" error_message="Please enter your email" />
+        <x-bladewind::input numeric="true" name="mobile2" label="Mobile" />
+    </form>
+
+    <x-bladewind::processing
+        name="profile-updating"
+        message="Updating your profile." />
+
+    <x-bladewind::process-complete
+        name="profile-update-yes"
+        process_completed_as="passed"
+        button_label="Done"
+        button_action="hideModal('form-mode-ajax')"
+        message="Profile updated successfully." />
+
+</x-bladewind::modal>
+```
+
+```js
+// the script called by the Update button
+saveProfileAjax = () => {
+    if(validateForm('.profile-form-ajax')){
+        // show process indicator while you make your ajax call
+        unhide('.profile-updating');
+        hide('.profile-form-ajax');
+        hideModalActionButtons('form-mode-ajax');
+        // make the call
+        makeAjaxCall(serialize('.profile-form-ajax'));
+    } else {
+        return false;
+    }
+}
+
+makeAjaxCall = (formData) => {
+    // this is a dummy function but your real function
+    // will make a call and post all the data
+    setTimeout(() => {
+        // do these when your ajax call is done saving your data
+        hide('.profile-updating');
+        unhide('.profile-update-yes')
+    }, 5000);
+}
+```
+
+`hide()`, `unhide()`, `hideModalActionButtons()`, `serialize()` and `validateForm()` are all [helper functions](/extra/helper-functions) available in BladewindUI.
+
+### Submit Button in Form
+
+The third option is to hide the Okay button of the modal and let the submit button sit in the form itself.
+
+```blade
+<x-bladewind::modal
+    backdrop_can_close="false"
+    name="form-mode-simple"
+    ok_button_label=""
+    >
+
+    <form method="get" action="" class="profile-form-simple"
+          onsubmit="return saveProfileSimple()">
+        @csrf
+        <b>Edit Your Profile</b>
+        <div class="grid grid-cols-2 gap-4 mt-6">
+            <x-bladewind::input required="true" name="first_name3"
+                label="First name" error_message="Please enter your first name" />
+            <x-bladewind::input required="true" name="last_name3"
+                label="Last name" error_message="Please enter your last name" />
+        </div>
+        <x-bladewind::input required="true" name="email3"
+                label="Email address" error_message="Please enter your email" />
+        <x-bladewind::input numeric="true" name="mobile3"
+                label="Mobile" />
+        <x-bladewind::button can_submit="true" class="w-full mt-2">
+            Update Profile
+        </x-bladewind::button>
+    </form>
+</x-bladewind::modal>
+```
+
+```js
+// the script called by the Update button
+saveProfileSimple = () => {
+    if(validateForm('.profile-form-simple')){
+        return domEl('.profile-form-simple').submit();
+    }
+    return false;
+}
+```
+
+## Replacing Placeholders
+
+There are times you will want to replace placeholders in the content of your modals. An example is when you are deleting a record and want the user to confirm. With placeholders your message could become: **Do you really want to delete :name as an admin?**
+
+```blade
+<x-bladewind::modal
+    name="placeholder-example"
+    title="Confirm"
+    type="error">
+    Hey :auth_user, to delete <b>:name</b>,
+    first delete all the pictures they have uploaded
+</x-bladewind::modal>
+```
+
+```blade
+<x-bladewind::table>
+    ...
+    <tr>
+        <td>Alfred Rowe</td>
+        <td>Outsourcing</td>
+        <td>alfred@therowe.com</td>
+        <td>
+            <x-bladewind::button
+            size="tiny"
+            color="red"
+            onclick="showModal('placeholder-example', {
+                auth_user: 'mike',
+                name: 'Alfred Rowe'
+            })">Delete</x-bladewind::button></td>
+    </tr>
+    ...
+</x-bladewind::table>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| type | blank | `info` `error` `warning` `success` |
+| title | blank | String. Defines the title of the modal |
+| name | `'bw-modal-'.uniqid()` | Uniquely identifies a modal. Very important to prevent erratic behaviour |
+| ok_button_label | `okay` | Specify the label to be displayed on the primary action button |
+| cancel_button_label | `cancel` | Specify the label to be displayed on the secondary action button |
+| ok_button_action | `close` | Expects a javascript function that will be called when the primary action button is clicked |
+| cancel_button_action | `close` | Expects a javascript function that will be called when the secondary action button is clicked |
+| close_after_action | `true` | Specify whether the modal stays open after any of the action buttons are clicked. `true` `false` |
+| backdrop_can_close | `true` | Specify whether clicking on the modal backdrop should close the modal. `true` `false` |
+| blur_size | `medium` | Specify the intensity of the backdrop blur. `none` `small` `medium` `large` `xl` `omg` |
+| show_action_buttons | `true` | Specify whether the action buttons should be displayed. `true` `false` |
+| align_buttons | `right` | Specify how the action buttons should be aligned in the modal footer. `left` `center` `right` |
+| stretch_action_buttons | `false` | Specify whether the action buttons should stretch the entire width of the modal. `true` `false` |
+| size | `big` | Defines the size of the modal. `tiny` `small` `medium` `large` `xl` `omg` |
+| show_close_icon | `false` | Display a close icon in the top right corner of the modal window. `true` `false` |
+| body_css | blank | Any extra css classes to add to the modal body |
+| footer_css | blank | Any extra css classes to add to the modal footer |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts |
+
+## Full Example
+
+```blade
+<x-bladewind::modal
+    type="warning"
+    title="Modal with all features"
+    name="full-modal"
+    ok_button_label="yes"
+    cancel_button_label="no"
+    close_after_action="false"
+    ok_button_action="alert('say ok')"
+    cancel_button_action="alert('say nay')"
+    backdrop_can_close="false"
+    show_action_buttons="false"
+    show_close_icon="true"
+    blur_size="xxl"
+    size="medium"
+    class="shadow-sm">
+    ...
+</x-bladewind::modal>
+```

--- a/mcp/notification.md
+++ b/mcp/notification.md
@@ -1,0 +1,72 @@
+---
+title: Notification Component
+component: x-bladewind::notification
+url: /component/notification
+---
+
+# Notification
+
+Unlike the [Alert](/component/alert) component, the notification component is not permanently visible and is useful when you want to provide feedback to your users. The BladewindUI Notification component is solely triggered via JavaScript.
+
+Include the component anywhere on your page — ideally in a shared layout so it is available globally.
+
+## Basic Usage
+
+```blade
+<x-bladewind::notification />
+```
+
+Trigger a notification using the JavaScript helper function:
+
+```js
+showNotification(title, message, type, dismiss_in);
+```
+
+| Parameter | Required | Description |
+|---|---|---|
+| title | optional | Brief title of the notification |
+| message | required | Message to display in the body |
+| type | optional | `success` (default) \| `info` \| `warning` \| `error` |
+| dismiss_in | optional | Seconds before auto-dismiss. Default is 15 |
+
+```js
+showNotification('Delete Successful', 'Your file was deleted successfully');
+
+showNotification('Delete Failed', 'Your message could not be deleted. Try again', 'error');
+
+showNotification('Low Disk Space', 'You have used 20gb of your 25gb storage space.', 'warning');
+
+showNotification('Invitation Accepted', 'Samuel just accepted your invitation.', 'info');
+```
+
+## Multiple Notifications
+
+Multiple notifications can be triggered and are displayed as a stack, with the latest on top.
+
+## Targeting Existing Notifications
+
+By default, each `showNotification()` call creates a new notification. To prevent duplicate notifications (e.g., repeated file type errors), give the notification a `name` as the 6th parameter. BladewindUI will re-render the existing notification instead of creating a new one.
+
+```js
+showNotification(
+    'Delete Failed',
+    'Your message could not be deleted. Try again',
+    'error',
+    15,
+    'regular',
+    'same_one'
+);
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| position | top-right | Where to display notifications. `top-right` \| `bottom-right` \| `top-left` \| `bottom-left` |
+| nonce | null | Nonce value for Content Security Policy |
+
+## Full Example
+
+```blade
+<x-bladewind::notification position="top-right" />
+```

--- a/mcp/number.md
+++ b/mcp/number.md
@@ -1,0 +1,101 @@
+---
+title: Number Component
+component: x-bladewind::number
+url: /component/number
+---
+
+# Number
+
+Display a number input that allows incrementing and decrementing values via up/down buttons. Extends the BladewindUI [Input](/component/input) component using prefix/suffix icons and `numeric="true"`.
+
+## Basic Usage
+
+```blade
+<x-bladewind::number />
+
+{{-- increment/decrement by 10 --}}
+<x-bladewind::number step="10" />
+```
+
+## Sizes
+
+Available sizes: `small`, `regular`, `medium` (default), `big`. Sizes match the Input component sizes.
+
+```blade
+<x-bladewind::number size="small" />
+<x-bladewind::number size="regular" />
+<x-bladewind::number size="medium" />
+<x-bladewind::number size="big" />
+```
+
+## Button Transparency
+
+By default the increment/decrement buttons are transparent. Set `transparent_icons="false"` to give them a solid background.
+
+```blade
+<x-bladewind::number transparent_icons="false" />
+<x-bladewind::number transparent_icons="false" size="big" />
+```
+
+## Labels
+
+Setting a `label` on a number with a default value (`selected_value`) moves the label to the top border of the field. Setting `selected_value=""` displays the label as a placeholder.
+
+```blade
+{{-- label at top border --}}
+<x-bladewind::number label="quantity" />
+
+{{-- label as placeholder --}}
+<x-bladewind::number selected_value="" label="quantity" />
+```
+
+## Minimum and Maximum Limits
+
+```blade
+<x-bladewind::number min="18" max="60" label="Your age" />
+```
+
+The component enforces limits — clicking past `max` does nothing, and manually typing out-of-range values resets them to the limit.
+
+## Form Values
+
+The `name` attribute is submitted with the form. A random name is used if none is specified.
+
+```php
+$request->age; // if name="age"
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | random | Name submitted with the form |
+| label | _(blank)_ | Label displayed in or above the component |
+| selected_value | null | Default value (edit mode) |
+| min | 0 | Minimum allowed value |
+| max | 100 | Maximum allowed value |
+| step | 1 | Increment/decrement amount |
+| size | medium | `small` \| `regular` \| `medium` \| `big` |
+| transparent_icons | true | Transparent increment/decrement buttons. `true` \| `false` |
+| icon_type | outline | Arrow icon style. `outline` \| `solid` |
+| with_dots | true | Allow decimal values. `true` \| `false` |
+| required | false | Append asterisk to label. `true` \| `false` |
+| class | _(blank)_ | Additional CSS classes for the input field |
+| nonce | null | Nonce value for Content Security Policy |
+
+## Full Example
+
+```blade
+<x-bladewind::number
+    name="age"
+    icon_type="outline"
+    required="false"
+    label="Age"
+    size="big"
+    transparent_icons="true"
+    min="18"
+    max="65"
+    step="10"
+    with_dots="false"
+    selected_value="12" />
+```

--- a/mcp/process-indicator.md
+++ b/mcp/process-indicator.md
@@ -1,0 +1,109 @@
+---
+title: Process Indicator Component
+component: x-bladewind::processing
+url: /component/process-indicator
+---
+
+# Process Indicator
+
+Show that a process is in progress and display the outcome when it completes. Best used inside a [Modal](/component/modal). There are two sub-components:
+
+- `x-bladewind::processing` — shown while a process is running
+- `x-bladewind::process-complete` — shown when the process finishes (pass or fail)
+
+## Basic Usage
+
+```blade
+{{-- show process running --}}
+<x-bladewind::processing
+    name="processing-delete"
+    message="Deleting pending payment"
+    hide="false" />
+
+{{-- show when process passes --}}
+<x-bladewind::process-complete
+    name="delete-payment-yes"
+    process_completed_as="passed"
+    button_label="Done"
+    button_action="hideModal('delete-paymentz')"
+    message="Pending payment was deleted successfully" />
+
+{{-- show when process fails --}}
+<x-bladewind::process-complete
+    name="delete-payment-no"
+    process_completed_as="failed"
+    button_label="Done"
+    button_action="hideModal('delete-paymentz')"
+    message="Pending payment could not be deleted" />
+```
+
+## Full Flow Example
+
+A typical pattern wraps all three parts inside a modal, then uses JavaScript to show the right element based on the API result.
+
+```blade
+<x-bladewind::modal name="delete-paymentz" show_action_buttons="false">
+    <x-bladewind::processing
+        name="processing-delete"
+        message="Deleting pending payment"
+        hide="false" />
+
+    <x-bladewind::process-complete
+        name="delete-payment-yes"
+        process_completed_as="passed"
+        button_label="Done"
+        button_action="alert('passed'); hideModal('delete-paymentz')"
+        message="Pending payment was deleted successfully" />
+
+    <x-bladewind::process-complete
+        name="delete-payment-no"
+        process_completed_as="failed"
+        button_label="Done"
+        button_action="alert('failed'); hideModal('delete-paymentz')"
+        message="Pending payment could not be deleted" />
+</x-bladewind::modal>
+```
+
+```js
+deletePayment = (mode) => {
+    hideHideables();
+    showModal('delete-paymentz');
+    unhide('.processing-delete');
+
+    setTimeout(function() {
+        hideHideables();
+        (mode == 'pass')
+            ? unhide('.delete-payment-yes')
+            : unhide('.delete-payment-no');
+    }, 3000);
+}
+
+hideHideables = () => {
+    hide('.processing-delete');
+    hide('.delete-payment-yes');
+    hide('.delete-payment-no');
+}
+```
+
+`hide()`, `unhide()`, and `showModal()` are BladewindUI JavaScript helpers.
+
+## Attributes
+
+### `x-bladewind::processing`
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | processing | Unique name for this component |
+| message | _(blank)_ | Message displayed below the spinner |
+| hide | true | Hidden by default. `true` \| `false` |
+
+### `x-bladewind::process-complete`
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | process-complete | Unique name for this component |
+| process_completed_as | passed | Determines the icon shown. `passed` shows green thumbs-up; `failed` shows red thumbs-down. `passed` \| `failed` |
+| message | _(blank)_ | Message displayed below the icon |
+| button_label | _(blank)_ | Label for the call-to-action button |
+| button_action | _(blank)_ | JavaScript to call when the button is clicked |
+| hide | true | Hidden by default. `true` \| `false` |

--- a/mcp/progress-bar.md
+++ b/mcp/progress-bar.md
@@ -1,0 +1,114 @@
+---
+title: Progress Bar Component
+component: x-bladewind::progress-bar
+url: /component/progress-bar
+---
+
+# Progress Bar
+
+Display progress as a horizontal bar filled to a given percentage. Includes a subtle fill animation. The default colour is blue (primary).
+
+## Basic Usage
+
+```blade
+<x-bladewind::progress-bar percentage="36" />
+```
+
+## Percentage Label
+
+```blade
+{{-- label inside the bar --}}
+<x-bladewind::progress-bar percentage="36" show_percentage_label="true" />
+
+{{-- label outside the bar (default position: top left) --}}
+<x-bladewind::progress-bar
+    percentage="36"
+    show_percentage_label="true"
+    show_percentage_label_inline="false" />
+
+{{-- label outside, positioned top center --}}
+<x-bladewind::progress-bar
+    percentage="53"
+    show_percentage_label="true"
+    show_percentage_label_inline="false"
+    percentage_label_position="top center" />
+
+{{-- with a suffix --}}
+<x-bladewind::progress-bar
+    percentage="75"
+    show_percentage_label="true"
+    show_percentage_label_inline="false"
+    percentage_suffix="complete" />
+```
+
+Available `percentage_label_position` values: `top-left` `top-center` `top-right` `bottom-left` `bottom-center` `bottom-right`
+
+## Colours
+
+Set `color` to any supported colour. Two shades are available via `shade`: `faint` (default) and `dark`.
+
+```blade
+{{-- faint shades --}}
+<x-bladewind::progress-bar percentage="10" color="red" />
+<x-bladewind::progress-bar percentage="20" color="yellow" />
+<x-bladewind::progress-bar percentage="30" color="green" />
+<x-bladewind::progress-bar percentage="40" color="pink" />
+<x-bladewind::progress-bar percentage="50" color="cyan" />
+<x-bladewind::progress-bar percentage="60" color="gray" />
+<x-bladewind::progress-bar percentage="70" color="purple" />
+<x-bladewind::progress-bar percentage="80" color="orange" />
+<x-bladewind::progress-bar percentage="80" color="violet" />
+<x-bladewind::progress-bar percentage="80" color="indigo" />
+<x-bladewind::progress-bar percentage="80" color="fuchsia" />
+
+{{-- dark shades --}}
+<x-bladewind::progress-bar percentage="50" color="red" shade="dark" />
+<x-bladewind::progress-bar percentage="20" color="yellow" shade="dark" />
+```
+
+## Striped and Animated
+
+```blade
+<x-bladewind::progress-bar percentage="60" color="red" shade="dark" striped="true" />
+
+<x-bladewind::progress-bar
+    percentage="50"
+    color="violet"
+    shade="dark"
+    striped="true"
+    animated="true" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| percentage | 0 | Fill percentage: 0–100 |
+| color | primary | Bar colour: `primary` `red` `yellow` `green` `blue` `pink` `cyan` `purple` `gray` `orange` `violet` `indigo` `fuchsia` |
+| shade | faint | Colour shade: `faint` \| `dark` |
+| show_percentage_label | false | Show the percentage label. `true` \| `false` |
+| show_percentage_label_inline | true | Show label inside the bar. `true` \| `false` |
+| percentage_label_position | top-left | Label placement when outside the bar. `top-left` \| `top-center` \| `top-right` \| `bottom-left` \| `bottom-center` \| `bottom-right` |
+| percentage_prefix | _(blank)_ | Text before the percentage label |
+| percentage_suffix | _(blank)_ | Text after the percentage label |
+| percentage_label_opacity | 100 | Opacity of the percentage label (TailwindCSS opacity value without the `opacity-` prefix) |
+| striped | false | Striped bar. `true` \| `false` |
+| animated | false | Animate the stripes (requires `striped="true"`). `true` \| `false` |
+| class | bw-progress-bar | Additional CSS classes |
+
+## Full Example
+
+```blade
+<x-bladewind::progress-bar
+    percentage="50"
+    color="red"
+    show_percentage_label="false"
+    show_percentage_label_inline="true"
+    percentage_label_position="top-left"
+    shade="faint"
+    percentage_prefix="uploading content: "
+    percentage_suffix="completed"
+    striped="true"
+    animated="true"
+    class="m-0" />
+```

--- a/mcp/progress-circle.md
+++ b/mcp/progress-circle.md
@@ -1,0 +1,151 @@
+---
+title: Progress Circle Component
+component: x-bladewind::progress-circle
+url: /component/progress-circle
+---
+
+# Progress Circle
+
+Display progress in a circular form based on a specified percentage. There is a subtle animation that can be turned off by setting `animate="false"`.
+
+This component borrows code from [Nikitahl](https://github.com/nikitahl) available [here](https://github.com/nikitahl/svg-circle-progress-generator).
+
+```blade
+<x-bladewind::progress-circle percentage="45" />
+```
+
+By default the progress circle label is not displayed. That can be changed by setting `show_label="true"`. The label (the percentage value) is then displayed but without the percentage sign. To display the percentage sign set the attribute `show_percent="true"`.
+
+```blade
+<x-bladewind::progress-circle percentage="58" show_label="true" />
+
+<x-bladewind::progress-circle
+    percentage="58"
+    show_label="true"
+    show_percent="true" />
+```
+
+## Different Colours
+
+You can display a progress circle in nine different colours by setting the `color` attribute to the preferred colour. Like most BladewindUI components that have colour options, there are two shades, `faint` and `dark`. The default shade is `faint` and the default colour is `blue`.
+
+### Faint Colours
+
+```blade
+<x-bladewind::progress-circle percentage="65" color="red" />
+<x-bladewind::progress-circle percentage="65" color="yellow" />
+<x-bladewind::progress-circle percentage="65" color="green" />
+<x-bladewind::progress-circle percentage="65" color="pink" />
+<x-bladewind::progress-circle percentage="65" color="cyan" />
+<x-bladewind::progress-circle percentage="65" color="gray" />
+<x-bladewind::progress-circle percentage="65" color="purple" />
+<x-bladewind::progress-circle percentage="65" color="orange" />
+<x-bladewind::progress-circle percentage="65" color="blue" />
+<x-bladewind::progress-circle percentage="65" color="violet" />
+<x-bladewind::progress-circle percentage="65" color="indigo" />
+<x-bladewind::progress-circle percentage="65" color="fuchsia" />
+```
+
+### Dark Colours
+
+```blade
+<x-bladewind::progress-circle percentage="65" shade="dark" color="red" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="yellow" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="green" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="pink" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="cyan" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="gray" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="purple" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="orange" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="blue" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="violet" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="indigo" />
+<x-bladewind::progress-circle percentage="65" shade="dark" color="fuchsia" />
+```
+
+## Different Sizes
+
+The progress circle comes in five prebuilt sizes with `medium` being the default size. To change the size of the circle set the `size` attribute. The available sizes are `tiny`, `small`, `medium`, `big`, `large`.
+
+```blade
+<x-bladewind::progress-circle
+    size="tiny"
+    percentage="10" />
+```
+
+## Custom Sizes
+
+It is quite difficult to determine the perfect circle size that'll fit designs we don't even know about. For this reason Bladewind allows you to specify a custom size for this component if the prebuilt sizes don't suit your needs. Set the `size` attribute to any number above 50.
+
+The prebuilt sizes and their corresponding pixel values are:
+
+| Size | Value |
+|---|---|
+| tiny | 50 |
+| small | 80 |
+| medium | 120 |
+| big | 200 |
+| large | 300 |
+
+```blade
+<x-bladewind::progress-circle
+    size="400"
+    percentage="89" />
+```
+
+You will notice from the example above the circle width is quite thin for a circle that big. To increase the width of the circle set the `circle_width` attribute to a reasonable value. The default value for custom circles is `10`.
+
+```blade
+<x-bladewind::progress-circle
+    size="400"
+    circle_width="50"
+    percentage="89" />
+```
+
+Things get a bit quirky when you need to display labels in custom circles. Because the circle size is unknown, it is a bit tricky to properly centre the label in the circle. There are additional attributes to help position the label properly in the circle.
+
+```blade
+<x-bladewind::progress-circle
+    percentage="73"
+    size="400"
+    circle_width="50"
+    text_size="50"
+    align="100"
+    valign="0"
+    show_label="true"
+    show_percent="true"
+/>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| percentage | 0 | Any value between 0 and 100. |
+| color | blue | There are twelve colors to choose from. `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` \| `violet` \| `indigo` \| `fuchsia` |
+| size | medium | The available sizes are: `tiny` \| `small` \| `medium` \| `big` \| `large` \| `custom` |
+| show_label | false | Should the percentage label be displayed. `true` \| `false` |
+| show_percent | false | Should the percentage sign be displayed. `true` \| `false` |
+| animate | true | Should the progress circle be animated when loaded. `true` \| `false` |
+| shade | faint | Works with `color` to determine how faint or dark the progress circle colours are. `faint` \| `dark` |
+| text_size | 30 | Controls how big the text should be. You can think of this as font size. Value can be any positive number. |
+| align | 40 | Controls the position of the text horizontally. You will need to keep tweaking this value until the text sits in a position you desire. |
+| valign | 0 | Controls the position of the text vertically. 0 keeps the text in the centre of the circle. Negative values will position the text towards the top of the circle. |
+| circle_width | 30 | Controls the thickness of the circle. Value can be any positive number. |
+
+## Full Example
+
+```blade
+<x-bladewind::progress-circle
+    percentage="50"
+    color="red"
+    show_label="false"
+    show_percent="false"
+    animate="true"
+    size="medium"
+    circle_width="50"
+    text_size="50"
+    align="100"
+    valign="0"
+    shade="faint" />
+```

--- a/mcp/radio-button.md
+++ b/mcp/radio-button.md
@@ -1,0 +1,96 @@
+---
+title: Radio Button Component
+component: x-bladewind::radio
+url: /component/radio-button
+---
+
+# Radio Button
+
+Display a radio button with or without a label. The default radio button colour is blue but there are nine colours available to choose from.
+
+```blade
+<x-bladewind::radio name="tnc" />
+```
+
+Radio buttons are often used in groups. Give each radio in a group the same `name` to make them mutually exclusive.
+
+```blade
+<x-bladewind::radio label="Action" name="genre" />
+<x-bladewind::radio label="Comedy" name="genre" />
+<x-bladewind::radio label="Drama" name="genre" />
+<x-bladewind::radio label="Thriller" name="genre" />
+```
+
+A radio button can be checked by default using `checked="true"`.
+
+```blade
+<x-bladewind::radio
+    label="I am checked by default"
+    checked="true"
+    name="check_me" />
+```
+
+Radio buttons can also be disabled.
+
+```blade
+<x-bladewind::radio
+    label="I am disabled"
+    disabled="true" />
+```
+
+## Coloured Radio Buttons
+
+Like most of the BladewindUI components, radios also come in twelve colours to enable the components sit better in most designs with various colour schemes.
+
+```blade
+<x-bladewind::radio color="red" checked="true" label="I am a red radio" />
+<x-bladewind::radio color="yellow" label="I am a yellow radio" />
+<x-bladewind::radio color="green" label="I am a green radio" />
+<x-bladewind::radio color="pink" label="I am a pink radio" />
+<x-bladewind::radio color="cyan" label="I am a cyan radio" />
+<x-bladewind::radio color="black" label="I am a black radio" />
+<x-bladewind::radio color="purple" label="I am a purple radio" />
+<x-bladewind::radio color="orange" label="I am an orange radio" />
+<x-bladewind::radio color="blue" label="I am a blue radio" />
+<x-bladewind::radio color="violet" label="I am a violet radio" />
+<x-bladewind::radio color="indigo" label="I am an indigo radio" />
+<x-bladewind::radio color="fuchsia" label="I am a fuchsia radio" />
+```
+
+### Radio Buttons and Forms
+
+When using radio buttons with forms, it is always good practice to give the radio button a name and value. That way, when the form is submitted, the value of the radio button can be retrieved from its name. It is important to note that, in some cases, if the user does not select the radio button, the name of the radio button will be ignored completely from your payload.
+
+```blade
+<x-bladewind::radio
+    name="notify_me"
+    value="1"
+    label="Send me weekly newsletters" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | radio | This name can be accessed when the radio button is submitted in the form. The name is also available as part of the css classes. |
+| label | _blank_ | Text to be displayed next to the radio button. |
+| value | _blank_ | In case you are editing a form, the value passed will be set on the value attribute of the radio button. |
+| checked | false | Determines if the radio button is checked or not. Value needs to be set as a string not boolean. `true` \| `false` |
+| disabled | false | Determines if the radio button is disabled or not. Value needs to be set as a string not boolean. `true` \| `false` |
+| add_clearing | true | Adds a margin to the bottom of the radio button to separate it from the next form element. `true` \| `false` |
+| class | bw-radio button | Any additional css classes can be added using this attribute. |
+| color | blue | There are twelve colors to choose from. `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` \| `violet` \| `indigo` \| `fuchsia` |
+| label_css | mr-6 | Applies styling to the radio button label. |
+
+## Full Example
+
+```blade
+<x-bladewind::radio
+    label="I agree to the terms and conditions"
+    checked="false"
+    disabled="false"
+    color="pink"
+    name="tnc"
+    value="yes"
+    class="shadow-sm" />
+```

--- a/mcp/rating.md
+++ b/mcp/rating.md
@@ -1,0 +1,136 @@
+---
+title: Rating Component
+component: x-bladewind::rating
+url: /component/rating
+---
+
+# Rating
+
+Displays a five star rating system. The number of stars highlighted match the rating passed. There are nine star colors to choose from but the default is `orange`. Where there are multiple ratings on the same page, it is recommended to name each rating component. You can either display ratings as stars, hearts or thumbsup.
+
+```blade
+<x-bladewind::rating name="star-rating" />
+```
+
+```blade
+<x-bladewind::rating
+    type="heart"
+    name="heart-rating" />
+```
+
+```blade
+<x-bladewind::rating
+    type="thumbsup"
+    name="thumb-rating" />
+```
+
+## Different Colors
+
+The BladewindUI rating component allows you to specify different colours. There are twelve colour options to pick from.
+
+```blade
+<x-bladewind::rating rating="1" color="red" name="red-rating" />
+<x-bladewind::rating rating="2" color="yellow" name="yellow-rating" />
+<x-bladewind::rating rating="3" color="green" name="green-rating" />
+<x-bladewind::rating rating="4" color="blue" name="blue-rating" />
+<x-bladewind::rating rating="5" color="pink" name="pink-rating" />
+<x-bladewind::rating rating="1" color="cyan" name="cyan-rating" />
+<x-bladewind::rating name="orange-rating" />
+<x-bladewind::rating rating="3" color="gray" name="gray-rating" />
+<x-bladewind::rating rating="4" color="purple" name="purple-rating" />
+<x-bladewind::rating rating="4" color="violet" name="violet-rating" />
+<x-bladewind::rating rating="4" color="indigo" name="indigo-rating" />
+<x-bladewind::rating rating="4" color="fuchsia" name="fuchsia-rating" />
+```
+
+## Different Sizes
+
+The BladewindUI rating component comes not just in colors but also sizes. There are three sizes available. The default size is `small`.
+
+```blade
+<x-bladewind::rating rating="2" name="small-rating" />
+
+<x-bladewind::rating
+    size="medium"
+    type="thumbsup"
+    rating="3"
+    name="medium-rating" />
+
+<x-bladewind::rating
+    size="big"
+    type="heart"
+    rating="2"
+    name="big-rating" />
+```
+
+## Click Actions
+
+A hidden input field is created in the background with every rating component that is created. The input field uses the `name` attribute set for the rating component to uniquely identify and update the hidden input. Assuming you named your rating component `small-rating`, the following hidden input will be created. The name is prefixed with `rating-value-` so the resulting name will be `rating-value-small-rating`.
+
+```blade
+<input type="hidden" class="rating-value-small-rating" value="2" />
+```
+
+You can access this element via Javascript using the custom function you pass to the `onclick` attribute.
+
+```blade
+<x-bladewind::rating
+    rating="2"
+    name="small-rating"
+    onclick="saveRating('small-rating')" />
+```
+
+```blade
+<script>
+    saveRating = function(element) {
+
+        // element here is the corresponding rating component.
+        // dom_el() is a helper function in BladewindUI
+        // access the value of the element
+
+        let element_value = dom_el(`::rating-value-${element}`).value;
+
+        // now that you have the rating value you can save it
+        // maybe via an ajax call.. completely up to you
+        ajaxCall(
+            'post',
+            '/article/rating/save',
+            `rating=${element_value}`
+        );
+    }
+</script>
+```
+
+## Disabled Click Actions
+
+In designs we are not always asking users to rate. There are times the user has already rated, and we need to display the ratings as readonly. In such cases the hover and click actions need to be disabled so the user won't modify the value of the rating. This can be achieved by setting `clickable="false"`.
+
+```blade
+<x-bladewind::rating rating="4" clickable="false" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | rating | The name to uniquely identify the component by. |
+| color | orange | There are twelve colors to choose from. `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` \| `violet` \| `indigo` \| `fuchsia` |
+| type | star | Determines the type of icon to display ratings as. `star` \| `heart` \| `thumbsup` |
+| size | small | Determines the size of the stars. `small` \| `medium` \| `big` |
+| rating | 0 | Determines the default rating for the component. Any number between 0 and 5. The number of stars highlighted will depend on the number passed. |
+| onclick | _blank_ | Javascript function to execute when stars are clicked. |
+| clickable | true | Enable or disable click actions. `true` \| `false` |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. For convenience, you can set your `nonce` value in the `config/bladewind.php` file under the "script" key. |
+
+## Full Example
+
+```blade
+<x-bladewind::rating
+    type="heart"
+    name="album-rating"
+    rating="3"
+    color="yellow"
+    size="big"
+    clickable="true"
+    onclick="alert('you clicked on a star')" />
+```

--- a/mcp/select.md
+++ b/mcp/select.md
@@ -1,0 +1,491 @@
+---
+title: Select Component
+component: x-bladewind::select
+url: /component/select
+---
+
+# Select
+
+Select single or multiple values from a list.
+
+If you have multiple select components on a page, it is important to give each one a **unique** name. Failure to do this will result in erratic behaviour of the component. If you specify no name, the component sets a unique name.
+
+## Basic Usage
+
+The `data` attribute is what really drives the BladewindUI select component. This attribute expects an `array` to be passed to it. The default array keys used to render the select are `label` and `value`.
+
+```blade
+<?php
+    $countries = [
+        [ 'label' => 'Benin',         'value' => 'bj' ],
+        [ 'label' => 'Burkina Faso',  'value' => 'bf' ],
+        [ 'label' => 'Ghana',         'value' => 'gh' ],
+        [ 'label' => 'Nigeria',       'value' => 'ng' ],
+        [ 'label' => 'Kenya',         'value' => 'ke' ]
+    ];
+```
+
+```blade
+<x-bladewind::select
+    name="country"
+    :data="$countries" />
+```
+
+Below is an alternative way to pass `data` to the component. Note there is no colon before the data attribute and in this case the data is passed as a json encoded string.
+
+```blade
+<x-bladewind::select
+    name="country"
+    data="{{ json_encode($countries) }}" />
+```
+
+### Change Placeholder Text
+
+```blade
+<x-bladewind::select
+    name="country2"
+    placeholder="What is your nationality"
+    :data="$countries" />
+```
+
+### Use Labels Instead of Placeholders
+
+Placeholders tell the user what to enter into the field and disappear once the user selects a value. Labels on the other hand are always visible. The BladewindUI Select defaults to using placeholders. To use labels, set the `label` attribute. When both a placeholder and label are defined, the label takes precedence.
+
+```blade
+<x-bladewind::select name="labels" required="true" :data="$countries"
+    label="Where are you from?"/>
+```
+
+### Setting the Value and Label Keys
+
+It is not feasible to always rewrite your arrays to use the `value` and `label` keys expected by the component. Use the `label_key` and `value_key` attributes to map your own keys.
+
+```blade
+<x-bladewind::select
+    name="country_mixed"
+    label_key="country"
+    value_key="code"
+    :data="$countries" />
+```
+
+### Selecting a Value By Default
+
+Like with the regular HTML `<select>` field, it is possible to have an item selected by default when the page loads. Useful when editing records.
+
+```blade
+<x-bladewind::select
+    name="country-select"
+    selected_value="gh"
+    placeholder="What is your nationality"
+    :data="$countries" />
+```
+
+### Required Field
+
+Setting a select as required appends a red asterisk to the placeholder text.
+
+```blade
+<x-bladewind::select
+    name="country-select2"
+    required="true"
+    placeholder="What is your nationality"
+    :data="$countries" />
+```
+
+### Disabled Select
+
+A disabled select has a 50% opacity and a cursor indicating the field cannot be accessed.
+
+```blade
+<x-bladewind::select
+    name="country-dis"
+    disabled="true"
+    placeholder="What is your nationality"
+    :data="$countries" />
+```
+
+### Readonly Select
+
+A readonly select is quite visible but cannot be opened to view the list of items.
+
+```blade
+<x-bladewind::select
+    name="country-ro"
+    readonly="true"
+    placeholder="What is your nationality"
+    :data="$countries" />
+```
+
+## With Country Flags
+
+This is a simple way for users displaying lists of countries to show flags next to each country name. This implementation was ported from [Semantic UI library's flags](https://semantic-ui.com/elements/flag.html) feature. Flags are rendered using the country's ISO code. You will need to specify the `flag_key` attribute on the select — this should be the name of the key in your array that has the country codes.
+
+```blade
+<x-bladewind::select
+    name="country"
+    label_key="country"
+    value_key="code"
+    flag_key="code"
+    :data="$countries" />
+```
+
+For flags to work you will need to include the following stylesheet. It is deliberately not compiled into the core BladewindUI css because not everyone needs flags.
+
+```blade
+<link href="{{ asset('vendor/bladewind/css/flags.css') }}" rel="stylesheet" />
+```
+
+## With Images
+
+You may wish to include images in your select list. Specify the `image_key` attribute on the select — this should be the name of the key in your array that has the image urls.
+
+```blade
+<x-bladewind::select
+    name="staff"
+    placeholder="Assign task to"
+    label_key="name"
+    value_key="id"
+    image_key="picture"
+    :data="$staff" />
+```
+
+## Searchable Select
+
+Set `searchable="true"` to make the Select component searchable. This is turned off by default.
+
+```blade
+<x-bladewind::select
+     name="country4"
+     searchable="true"
+     label_key="country"
+     value_key="code"
+     flag_key="code"
+     :data="$countries" />
+```
+
+## Empty Select
+
+When pulling dynamic data from APIs or a database, you will not always have data available. In cases like this the Select component will display the message in the `empty_placeholder` attribute. If you set `searchable="true"` but there is no data to display, the search bar will automatically be hidden.
+
+```blade
+<x-bladewind::select name="empty_users" searchable="true" :data="$users" />
+```
+
+### Display as Empty State
+
+It is possible to leverage the BladewindUI [Empty State](/component/empty-state) component to display the empty message. Set the `empty_state_from` attribute to the name of an empty state component defined on the same page with `for_select="true"`.
+
+```blade
+<x-bladewind::empty-state
+    name="no_docs"
+    for_select="true"
+    message="Awesome! You have no documents to approve.">
+</x-bladewind::empty-state>
+```
+
+```blade
+<x-bladewind::select searchable="true" :data="$users"
+    empty_state_from="no_docs" />
+```
+
+## Select Multiple Items
+
+Set `multiple="true"` to allow selecting more than one item. Unlike the single select, multiple selects do not automatically close when you select items. To close a multiple select just click anywhere on the page outside the component.
+
+```blade
+<x-bladewind::select
+    name="country-multi"
+    searchable="true"
+    label_key="country"
+    value_key="code"
+    flag_key="code"
+    multiple="true"
+    label="Select a country"
+    max_selectable="3"
+    :data="$countries" />
+```
+
+If you try to select more than the value set in `max_selectable`, the selection will be blocked. The default value is -1, which means there is no limit on selection. You can set `max_error_message` to customize the error message shown when the limit is reached.
+
+### Automatic Selection of Items
+
+You can auto-select items by default using `selected_value` as a comma-separated list.
+
+```blade
+<x-bladewind::select
+    name="country-multi2"
+    searchable="true"
+    selected_value="gh, gm, ci, bf"
+    label_key="country"
+    value_key="code"
+    flag_key="code"
+    multiple="true"
+    :data="$countries" />
+```
+
+## Manually Building a Select
+
+There could be cases when your data will not come from an API call or array. Set `data="manual"` and use the child `x-bladewind::select.item` component to build the options.
+
+```blade
+<x-bladewind::select name="gender" placeholder="Select Gender" data="manual">
+    <x-bladewind::select.item label="Male" value="male" />
+    <x-bladewind::select.item label="Female" value="female" />
+    <x-bladewind::select.item label="Prefer not to say" value="other" />
+</x-bladewind::select>
+```
+
+The manual Select can inherit all the cool features of an array-based Select — searchable or multiple selection, with flags and images.
+
+```blade
+<x-bladewind::select
+    name="tags"
+    placeholder="Tags for this music"
+    multiple="true"
+    searchable="true" data="manual">
+
+    <x-bladewind::select.item label="Pop" value="pop" image="/path/to/image" />
+    <x-bladewind::select.item label="Hip" value="hip" flag="gh" />
+    <x-bladewind::select.item label="Trendy" value="trendy" flag="ng" />
+    <x-bladewind::select.item label="GenZ" value="genz" image="/path/to/image" />
+    <x-bladewind::select.item label="Trance" value="trance" />
+    <x-bladewind::select.item label="For Coder's" value="devs" />
+
+</x-bladewind::select>
+```
+
+## Get Value of Selected Item(s)
+
+Every BladewindUI select component creates a hidden form field `<input type="hidden" name="the-select-name-you-provided" />`. When you select an item, the hidden input field is updated with the value. You can access the value in Laravel via:
+
+```blade
+$request->get('country');
+$request->input('country');
+$request->country;
+```
+
+The **multiple select** generates a comma separated list of values. For example: `<input type="hidden" name="country_multi" value="gh,ci,bf,gm" />`.
+
+## Execute Custom Functions
+
+It is possible to execute a JavaScript custom function when an item is selected. Set `onselect="function_name"` — just the name without parenthesis. The value and label of the selected item are passed to the custom function as `onselect="prependDialingCode(value, label, all_values)"`. The third parameter `all_values` is useful for multiple selects.
+
+```blade
+<x-bladewind::select
+    name="cusfxns"
+    placeholder="Your country"
+    data="manual"
+    onselect="prependDialingCode">
+
+    <x-bladewind::select.item label="Burkina Faso" value="bf" />
+    <x-bladewind::select.item label="Ghana" value="gh" />
+    <x-bladewind::select.item label="Nigeria" value="ng" />
+
+</x-bladewind::select>
+```
+
+```blade
+// javascript
+const dialing_codes = {
+    'gh' : '+233',
+    'ng' : '+234',
+    'bf' : '+226'
+}
+
+prependDialingCode = (value) => {
+    domEl('.mobile-prefix').innerText = eval(`dialing_codes.${value}`);
+}
+```
+
+## Manipulate Selects from JavaScript
+
+When you create a Select component and provide a name, BladewindUI initializes the component in JavaScript using that name, prefixed with `bw_` and with dashes replaced by underscores.
+
+```blade
+// the following component declaration
+<x-bladewind::select name="country-multiple" placeholder="Select a country" />
+```
+
+```blade
+// will be initialized in JavaScript as
+const bw_country_multiple = new BladewindSelect('country_multiple', 'Select a country');
+```
+
+The following methods are available on the component from JavaScript:
+
+| Method | Description |
+|---|---|
+| enable | Enables the select and makes it clickable. `bw_country_multiple.enable();` |
+| disable | Disables the select and makes it non-clickable. `bw_country_multiple.disable();` |
+| reset | Removes any selected values from the component and empties the hidden input field. `bw_country_multiple.reset();` |
+| selectByValue(value) | Select one of the component values by value. `bw_country_multiple.selectByValue('gh');` |
+| filter(element, value) | Filter the items in `element` based on `value`. `bw_continents.filter('countries', 'AF');` |
+| clearFilter(element, value) | Clear all filtering in `element`. `bw_countries.clearFilter('countries');` |
+
+## Filtering
+
+### Dynamically Filter a Table Based on Selected Values
+
+Use the `onselect` attribute to pass a JavaScript function that filters DOM elements based on the selected values.
+
+```blade
+<x-bladewind::select
+    name="department"
+    onselect="filterEmployees"
+    placeholder="filter by department"
+    data="manual"
+    multiple="true">
+    <x-bladewind::select.item label="Field Workers" value="field" />
+    <x-bladewind::select.item label="Finance" value="finance" />
+    <x-bladewind::select.item label="Tech" value="tech" />
+    <x-bladewind::select.item label="Marketing" value="marketing" />
+    <x-bladewind::select.item label="Operations" value="operations" />
+</x-bladewind::select>
+```
+
+```blade
+filterEmployees = (value, label, all_values) => {
+    let employee_cards = domEls('.bw-contact-card');
+    let keywords = all_values.replaceAll(',','|');
+    let regex = new RegExp( `(${keywords})`, 'ig' );
+    employee_cards.forEach((el) => {
+        (! el.innerText.match(regex) ) ? hide(el, true) : unhide(el, true);
+    });
+}
+```
+
+### Filter a Select Component Based on Another Select
+
+Use `filter` and `filter_by` attributes to filter one select based on another. `filter` is the name of the target select to be filtered. `filter_by` is the key in the target select's data that should match the value of the source select.
+
+```blade
+<!-- the continents select component -->
+<x-bladewind::select name="continent" placeholder="Select Continent"
+    filter="continent-country"
+    data="manual">
+    <x-bladewind::select.item label="Africa" value="af" />
+    <x-bladewind::select.item label="Asia" value="as" />
+    <x-bladewind::select.item label="Europe" value="eu" />
+    <x-bladewind::select.item label="North America" value="na" />
+</x-bladewind::select>
+```
+
+```blade
+<!-- the countries select component -->
+<x-bladewind::select
+    name="continent-country"
+    placeholder="Select Country"
+    searchable="true"
+    data="{{ json_encode($countries) }}"
+    filter_by="continent_code"
+    empty-placeholder="no countries available"
+    label_key="name"
+    value_key="value" />
+```
+
+### Filter a Select Based on an Arbitrary Value
+
+The select exposes a `filter()` method that allows for runtime filtering from any element such as a link, button, or tag.
+
+```blade
+filterCountries = (continent) => {
+    // this is where we actually tell the component to filter
+    bw_continent_country2.filter('continent_country2', continent);
+}
+```
+
+## Native Select
+
+It is possible to use the plain old HTML `<select>` element with the `bw-raw-select` class to style it like other BladewindUI form components.
+
+```blade
+<select name="age" class="bw-raw-select">
+    <option value="">Are you above 18?</option>
+    <option value="yes">Yep! I am</option>
+    <option value="no">Nope but tell no one</option>
+    <option value="idk">I'd rather not say</option>
+</select>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | bw-select | Assigned to the hidden input created for the select. Accessed when the select is submitted in a form. |
+| placeholder | Select One | Default text displayed on the select. |
+| label | null | Text displayed on the select **as a label** (always visible). |
+| onselect | _blank_ | Custom function to call when an item is selected. Specify just the function name without parenthesis. |
+| :data | [] | Array of elements to display. |
+| data | [] | JSON-encoded array of elements to display. |
+| value_key | value | Which key in your array the select picks its values from. |
+| label_key | label | Which key in your array the select picks its labels from. |
+| flag_key | _blank_ | When using flags, which key in your array holds the country ISO codes. |
+| image_key | _blank_ | When using images, which key in your array holds the image urls. |
+| data_serialize_as | _blank_ | Submit the select's value under a different name than its `name` attribute. |
+| required | false | Appends a red asterisk to the placeholder text. `true` \| `false` |
+| selected_value | _blank_ | Value(s) to select by default. Accepts comma-separated values for multiple selects. |
+| searchable | false | Adds a search box above the select items. `true` \| `false` |
+| disabled | false | Disables the select. `true` \| `false` |
+| readonly | false | Makes the select readonly. `true` \| `false` |
+| multiple | false | Allows multiple items to be selected. `true` \| `false` |
+| add_clearing | true | Applies 12px bottom margin for spacing in forms. `true` \| `false` |
+| max_selectable | -1 | Maximum number of items that can be selected. -1 means no limit. Only applies when `multiple="true"`. |
+| max_error | Please select only %s items | Message shown when user exceeds `max_selectable`. `%s` is replaced with the number. |
+| filter | _blank_ | Name of the select component to filter when this select's value changes. |
+| filter_by | _blank_ | Key in the target select's data to use for filtering. |
+| modular | false | Adds `type="module"` to inline script tags. `true` \| `false` |
+| empty_placeholder | No options available | Text displayed when there are no items. |
+| empty_state | false | Displays an empty state component when no items are available. `true` \| `false` |
+| empty_state_message | No options available | Message for the empty state component. |
+| empty_state_button_label | Add | Action button text in the empty state. Leave blank to hide the button. |
+| empty_state_onclick | _blank_ | Javascript function to call when the empty state action button is clicked. |
+| empty_state_image | empty-state.svg | Image to display in the empty state. |
+| empty_state_show_image | true | Whether to show the image in the empty state. `true` \| `false` |
+| size | medium | Sizing to match other inputs and buttons. `small` \| `regular` \| `medium` \| `big` |
+| nonce | null | Nonce for Content Security Policy inline scripts. Can be set globally in `config/bladewind.php`. |
+
+### Select Item Attributes
+
+When manually listing select items, the following attributes are available on `x-bladewind::select.item`:
+
+| Attribute | Default | Description |
+|---|---|---|
+| value | value | Value of the item. |
+| label | label | Label of the item. |
+| flag | _blank_ | ISO code of country whose flag to display. |
+| image | _blank_ | URL of image to display for the item. |
+| selected | false | Determines if the item should be selected by default. `true` \| `false` |
+| max_selectable | -1 | Maximum number of items that can be selected. |
+| max_error | Please select only %s items | Message when user exceeds `max_selectable`. |
+
+## Full Example
+
+```blade
+<x-bladewind::select
+    name="country"
+    placeholder="What is your nationality"
+    label="What is your nationality"
+    onselect="confirmSelection"
+    data="{{ json_encode($countries) }}"
+    value_key="code"
+    label_key="country"
+    flag_key="code"
+    image_key=""
+    disabled="false"
+    readonly="true"
+    data_serialize_as="country_id"
+    required="true"
+    selected_value="1001"
+    max_selectable="3"
+    searchable="true"
+    empty_state="true"
+    empty_state_message="Define a user"
+    empty_state_onclick="alert('hey')"
+    empty_state_button_label="new user"
+    empty_state_image=""
+    empty_state_show_image="false"
+    filter="countries"
+    filter_by="continent_id"
+/>
+```

--- a/mcp/shimmer.md
+++ b/mcp/shimmer.md
@@ -1,0 +1,116 @@
+---
+title: Shimmer Component
+component: x-bladewind::shimmer
+url: /component/shimmer
+---
+
+# Shimmer
+
+Shimmers or loading placeholders are a great visual cue to tell users that content is loading.
+
+```blade
+<x-bladewind::shimmer />
+```
+
+```blade
+<x-bladewind::shimmer animation="alternate" />
+```
+
+Shimmers can be used in various ways. For example, you can use them to show a loading state for a list of items, card content, or even a form. You can use the `circle` attribute to create a circular shimmer.
+
+```blade
+<x-bladewind::shimmer circle="true" />
+```
+
+Since it is impossible to know all the possible layouts users will want to shimmer, the Bladewind Shimmer has been designed to be very simple. You specify your own `width` and `height` and stack up as many shimmers as needed to create the loading layout you want to depict.
+
+In the example below, we have created a shimmer that is depicting two loading contact cards. One vertical, the other horizontal.
+
+```blade
+<x-bladewind::card class="sm:w-1/3">
+    <x-bladewind::shimmer :circle="true" align="center" />
+    <x-bladewind::shimmer height="h-5" />
+    <x-bladewind::shimmer />
+    <x-bladewind::shimmer />
+    <x-bladewind::shimmer />
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind::card class="sm:w-2/3">
+    <div class="flex gap-4">
+        <div><x-bladewind::shimmer :circle="true" class="size-40" /></div>
+        <div class="grow">
+            <x-bladewind::shimmer height="h-5" />
+            <x-bladewind::shimmer class="w-[90%]" />
+            <x-bladewind::shimmer class="w-[80%]" />
+            <x-bladewind::shimmer />
+            <x-bladewind::shimmer class="w-[80%]" />
+            <x-bladewind::shimmer class="w-[85%]" />
+            <x-bladewind::shimmer class="w-[90%]" />
+            <x-bladewind::shimmer class="w-[80%]" />
+            <x-bladewind::shimmer />
+            <x-bladewind::shimmer />
+        </div>
+    </div>
+</x-bladewind::card>
+```
+
+If the shimmer is at its full width (`w-full`), you can use the `align` attribute to position the shimmer to the `center` or `right` of its parent container. The shimmer by default is set to `w-full` and aligned to the `left` if width is not `w-full`.
+
+### Alternating Animation
+
+By default the animation moves from left to right. You can change this by setting the `animation` attribute to `alternate`. This will cause the shimmer to animate from left to right and then right to left, creating a back and forth effect.
+
+```blade
+<x-bladewind::card class="sm:w-1/3">
+    <x-bladewind::shimmer animation="alternate" :circle="true" align="center" />
+    <x-bladewind::shimmer animation="alternate" height="h-5" />
+    <x-bladewind::shimmer animation="alternate" />
+    <x-bladewind::shimmer animation="alternate" />
+    <x-bladewind::shimmer animation="alternate" />
+</x-bladewind::card>
+```
+
+```blade
+<x-bladewind::card class="sm:w-2/3">
+    <div class="flex gap-4">
+        <div><x-bladewind::shimmer animation="alternate" :circle="true" class="size-40" /></div>
+        <div class="grow">
+            <x-bladewind::shimmer animation="alternate" height="h-5" />
+            <x-bladewind::shimmer animation="alternate" class="w-[90%]" />
+            <x-bladewind::shimmer animation="alternate" class="w-[80%]" />
+            <x-bladewind::shimmer animation="alternate" />
+            <x-bladewind::shimmer animation="alternate" class="w-[80%]" />
+            <x-bladewind::shimmer animation="alternate" class="w-[85%]" />
+            <x-bladewind::shimmer animation="alternate" class="w-[90%]" />
+            <x-bladewind::shimmer animation="alternate" class="w-[80%]" />
+            <x-bladewind::shimmer animation="alternate" />
+            <x-bladewind::shimmer animation="alternate" />
+        </div>
+    </div>
+</x-bladewind::card>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| circle | false | Display the shimmer as a circle. `true` \| `false` |
+| duration | 1.5s | How long it takes for the animation to complete. The bigger the value the slower the animation. Must include 's' for seconds. |
+| width | w-full | How wide the shimmer goes. Must be a valid TailwindCSS width. Examples: `w-90`, `w-[100px]`, `w-[80%]` |
+| height | h-2.5 | Height of the shimmer. Must be a valid TailwindCSS height. Examples: `h-10`, `h-[10px]`, `h-[2%]` |
+| class | _blank_ | Any additional css classes can be added using this attribute. |
+| animation | normal | Direction of the animation. `normal` \| `alternate` |
+
+## Full Example
+
+```blade
+<x-bladewind::shimmer
+    animation="alternate"
+    circle="true"
+    duration="3s"
+    width="w-90"
+    height="h-90"
+    align="right" />
+```

--- a/mcp/slider.md
+++ b/mcp/slider.md
@@ -1,0 +1,103 @@
+---
+title: Slider Component
+component: x-bladewind::slider
+url: /component/slider
+---
+
+# Slider
+
+Select values from a slider. This provides a convenient way for users to select numeric values instead of clicking increment and decrement arrows or manually entering values.
+
+It is important to give your Slider a name if you intend to get the selected value when a form is submitted or via ajax. If you have multiple sliders on the same page, each slider needs to have a unique name. BladewindUI will use random names if you don't specify any.
+
+```blade
+<x-bladewind::slider />
+```
+
+## Different Colours
+
+The Slider component supports multiple colours. The default colour is your project's primary colour defined in your TailwindCSS config file. To use a different colour, set the `color` attribute. The `selected` attribute is useful in edit mode to specify the slider number the user already selected. It can also be used to set the default value for the slider.
+
+```blade
+<x-bladewind::slider selected="50" color="cyan" />
+<x-bladewind::slider selected="30" color="pink" />
+<x-bladewind::slider selected="70" color="indigo" />
+```
+
+## Step
+
+By default the slider increments by 1 when you slide. You can define the numeric interval between slides by setting the `step` attribute. This must be a positive number greater than 1.
+
+```blade
+<x-bladewind::slider selected="10" step="5" />
+```
+
+## Min and Max Values
+
+By default the slider is set to a minimum of 0 and maximum of 100. This behaviour can be changed by setting the `min` and `max` attributes. These must be positive numbers.
+
+```blade
+<x-bladewind::slider min="18" max="35" />
+```
+
+## Range Selection
+
+There are cases where you need to let users select a minimum and maximum value. Setting the slider attribute `range="true"` displays two markers on the slider for users to select two values.
+
+> Note: The range selection slider is currently buggy.
+
+```blade
+<x-bladewind::slider range="true" selected="20" max_selected="60" />
+```
+
+## Form Submission
+
+The `name` you specify for the slider is what will be passed when your form is submitted. Assuming you named your slider `age`, below is the HTML input field that will be generated.
+
+```blade
+<input type="hidden"
+       name="age"
+       id="age"
+       class="slider-selection-age-input bw-slider-age"
+       value="50" />
+```
+
+```blade
+<!-- when using a range slider and two values are selected -->
+<input type="hidden"
+       name="age"
+       id="age"
+       class="slider-selection-age-input bw-slider-age"
+       value="10,50" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | bw_uniqid() | Unique name for the slider. You can get the slider value from this when a form with a slider is submitted. |
+| color | primary | There are twelve colours to choose from. `primary` \| `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` \| `violet` \| `indigo` \| `fuchsia` |
+| show_values | true | Should the selected values label be displayed. `true` \| `false` |
+| range | false | Should the slider show two markers instead of one. `true` \| `false` |
+| min | 0 | Minimum value the slider should start from. Needs to be a positive number greater or equal to zero. |
+| max | 100 | Maximum value the slider should end at. Needs to be a positive number greater than zero. |
+| step | 1 | By what number should the slider values be incremented or decreased. Needs to be a positive number greater than zero. |
+| selected | 0 | Used in edit mode to set the slider to the number user selected previously. Also used to set the default value for the slider. The `max` value is used when a `selected` value is greater than the `max` value. |
+| max_selected | _blank_ | Applies only if `range="true"`. Sets the slider value for the second marker. Also used to set the default value for the second marker. |
+| class | bw-slider-container | Any additional css you wish to add. |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. For convenience, you can set your `nonce` value in the `config/bladewind.php` file under the "script" key. |
+
+## Full Example
+
+```blade
+<x-bladewind::slider
+    min="5"
+    max="50"
+    color="red"
+    show_values="false"
+    step="5"
+    range="true"
+    selected="34"
+    max_selected="45"
+    class="m-0" />
+```

--- a/mcp/spinner.md
+++ b/mcp/spinner.md
@@ -1,0 +1,62 @@
+---
+title: Spinner Component
+component: x-bladewind::spinner
+url: /component/spinner
+---
+
+# Spinner
+
+Display a spinning icon.
+
+```blade
+<x-bladewind::spinner />
+```
+
+## Different Colours
+
+The spinner supports multiple colours. The default colour is `gray`.
+
+```blade
+<x-bladewind::spinner />
+<x-bladewind::spinner color="primary" />
+<x-bladewind::spinner color="red" />
+<x-bladewind::spinner color="yellow" />
+<x-bladewind::spinner color="green" />
+<x-bladewind::spinner color="blue" />
+<x-bladewind::spinner color="purple" />
+<x-bladewind::spinner color="pink" />
+<x-bladewind::spinner color="orange" />
+<x-bladewind::spinner color="cyan" />
+<x-bladewind::spinner color="violet" />
+<x-bladewind::spinner color="indigo" />
+<x-bladewind::spinner color="fuchsia" />
+```
+
+## Different Sizes
+
+There are five sizes available. The default size is `small`.
+
+```blade
+<x-bladewind::spinner size="small" />
+<x-bladewind::spinner size="medium" />
+<x-bladewind::spinner size="big" />
+<x-bladewind::spinner size="xl" />
+<x-bladewind::spinner size="omg" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| size | small | The size of the spinner. `small` \| `medium` \| `big` \| `xl` \| `omg` |
+| color | gray | Set the colour of the spinner. `primary` \| `blue` \| `red` \| `yellow` \| `green` \| `purple` \| `pink` \| `orange` \| `gray` \| `cyan` \| `violet` \| `indigo` \| `fuchsia` |
+| class | bw-spinner | Any additional css you wish to add. |
+
+## Full Example
+
+```blade
+<x-bladewind::spinner
+    size="medium"
+    color="blue"
+    class="m-0" />
+```

--- a/mcp/statistic.md
+++ b/mcp/statistic.md
@@ -1,0 +1,110 @@
+---
+title: Statistic Component
+component: x-bladewind::statistic
+url: /component/statistic
+---
+
+# Statistic
+
+Display numeric summaries — most commonly used on dashboards. The component takes up the full width of its parent element and expects a `label` and a `number`. Numbers are displayed as-is; format thousand separators and decimals yourself.
+
+## Basic Usage
+
+```blade
+<x-bladewind::statistic number="34,500,100" label="Total payments" />
+
+{{-- label below the number --}}
+<x-bladewind::statistic
+    label_position="bottom"
+    number="34,500,100"
+    label="Total payments" />
+```
+
+## With Icons
+
+Icons are defined via the `icon` slot and can be placed on the left (default) or right.
+
+```blade
+{{-- icon on the left --}}
+<x-bladewind::statistic number="34,500,100" label="Total payments">
+    <x-slot name="icon">
+        <svg class="h-16 w-16 p-2 text-white rounded-full bg-blue-500" ...>
+            ...
+        </svg>
+    </x-slot>
+</x-bladewind::statistic>
+
+{{-- icon on the right --}}
+<x-bladewind::statistic icon_position="right" number="34,500,100" label="Total payments">
+    <x-slot name="icon">
+        <svg class="h-16 w-16 p-2 text-white rounded-full bg-orange-500" ...>
+            ...
+        </svg>
+    </x-slot>
+</x-bladewind::statistic>
+```
+
+## With Currency
+
+```blade
+<x-bladewind::statistic currency="GHS" number="34,500,100" label="Total payments" />
+
+{{-- currency in the label instead --}}
+<x-bladewind::statistic number="34,500,100" label="Total payments (GHS)" />
+```
+
+The currency symbol is displayed at a smaller font size than the number. Use `currency_position` to place it left (default) or right of the number.
+
+## With Spinners
+
+Show a spinner while fetching the number (e.g., from an API).
+
+```blade
+<x-bladewind::statistic label="Total payments" show_spinner="true" />
+```
+
+Hide the spinner programmatically once the value loads. Give the statistic a `class` name to target it:
+
+```js
+hide('.total-payments .bw-spinner');
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| label | _(blank)_ | Description of the statistic |
+| number | _(blank)_ | The number to display |
+| label_position | top | Position of label relative to number. `top` \| `bottom` |
+| currency | _(blank)_ | Currency symbol to display alongside the number |
+| currency_position | left | Position of the currency symbol. `left` \| `right` |
+| icon | _(blank)_ | SVG or image icon via slot |
+| icon_position | left | Position of the icon. `left` \| `right` |
+| show_spinner | false | Show a loading spinner. `true` \| `false` |
+| has_shadow | true | Show a drop shadow. `true` \| `false` |
+| has_border | true | Show a border. `true` \| `false` |
+| url | null | URL or JS function to call on click |
+| radius | small | Corner radius. `none` \| `small` \| `medium` \| `large` \| `xl` |
+| class | bw-statistic | Additional CSS classes (use to give the component a unique name for JS targeting) |
+
+## Full Example
+
+```blade
+<x-bladewind::statistic
+    label="Total payments"
+    label_position="bottom"
+    number="34,500,100"
+    currency="XOF"
+    currency_position="right"
+    icon_position="right"
+    has_shadow="false"
+    has_border="false"
+    show_spinner="true"
+    class="m-0">
+
+    <x-slot name="icon">
+        <svg>...</svg>
+    </x-slot>
+
+</x-bladewind::statistic>
+```

--- a/mcp/tab.md
+++ b/mcp/tab.md
@@ -1,0 +1,234 @@
+---
+title: Tab Component
+component: x-bladewind::tab
+url: /component/tab
+---
+
+# Tab
+
+Organize and display data in tabs. The BladewindUI tab component is broken down into two parts: the tab headings and the tab content. To prevent erratic behaviour of tabs it is very important to provide a value for the `name` attribute. In fact, the tabs won't be rendered without you specifying a name.
+
+Let us breakdown what is happening with the tab component. We first define a tab group that will hold all the tab headings and tab content. It is very important to give this tab group a name: `<x-bladewind::tab name="staff-loans">`.
+
+Next, we need to define the tab headings we will click on to access the tab content. The tab headings are wrapped in a `slot` named `headings`: `<x-slot:headings>`. The next step is to add the individual tab headings using `<x-bladewind::tab.heading />`. The individual tab headings also need to be named uniquely. The tab heading you want selected by default should have `active="true"`. This necessarily does not need to be the first tab.
+
+The final bit that ties the tab component all together is `<x-bladewind::tab.body>`. This is the parent component that holds all the content for each corresponding tab heading. Content for each tab heading needs to be defined in the `<x-bladewind::tab.content>` tag that has the **_same name_** as its corresponding tab heading. The tab content that needs to be visible by default also needs to have `active="true"` set.
+
+```blade
+<x-bladewind::tab name="free-pics">
+
+    <x-slot:headings>
+        <x-bladewind::tab.heading
+            name="unsplash-1" label="Lissete Laverde" />
+
+        <x-bladewind::tab.heading
+            name="unsplash-2" label="Marko Pavlichenko" />
+
+        <x-bladewind::tab.heading
+            name="unsplash-3" active="true" label="Yoonbae Cho" />
+
+        <x-bladewind::tab.heading
+            name="unsplash-4" label="Sam Carter" />
+    </x-slot:headings>
+
+    <x-bladewind::tab.body>
+
+        <x-bladewind::tab.content name="unsplash-1">
+            <img src="/path/to/the/image/file"
+                alt="Picture by Lissete Laverde" />
+        </x-bladewind::tab.content>
+
+        <x-bladewind::tab.content name="unsplash-2">
+            <img src="/path/to/the/image/file"
+                alt="Picture by Marko Pavlichenko" />
+        </x-bladewind::tab.content>
+
+        <x-bladewind::tab.content name="unsplash-3" active="true">
+            <img src="/path/to/the/image/file"
+                alt="Picture by Yoonbae Cho" />
+        </x-bladewind::tab.content>
+
+        <x-bladewind::tab.content name="unsplash-4">
+            <img src="/path/to/the/image/file"
+                alt="Picture by Sam Carter" />
+        </x-bladewind::tab.content>
+
+    </x-bladewind::tab.body>
+
+</x-bladewind::tab>
+```
+
+## Different Colours
+
+The tab component by default displays the active tab heading and its underline bar as blue. There are nine colours in total to pick from. To set your preferred colour set the `color` attribute on the `<x-bladewind::tab>` component.
+
+```blade
+<x-bladewind::tab name="red-tab" color="red">
+    ...
+</x-bladewind::tab>
+```
+
+Available colours: `primary` `red` `yellow` `green` `blue` `pink` `cyan` `purple` `gray` `orange` `violet` `indigo` `fuchsia`
+
+## Other Tab Styles
+
+The tab components exist in three different styles. You can specify a preferred style by setting the `style` attribute. The available styles are _simple_, _system_ and _pills_. The default tab style is _simple_.
+
+### System Tab Style
+
+```blade
+<x-bladewind::tab
+    name="sys-blue-tab"
+    style="system">
+
+    <x-slot:headings>
+        <x-bladewind::tab.heading
+            name="sys-blue" active="true" label="Blue System Tab" />
+        <x-bladewind::tab.heading
+            name="inactive-sys-blue" label="The Other Tab" />
+    </x-slot:headings>
+
+    <x-bladewind::tab.body>
+        <x-bladewind::tab.content
+            name="sys-blue" active="true">...</x-bladewind::tab.content>
+        <x-bladewind::tab.content
+            name="inactive-sys-blue">...</x-bladewind::tab.content>
+    </x-bladewind::tab.body>
+
+</x-bladewind::tab>
+```
+
+### Pills Tab Style
+
+```blade
+<x-bladewind::tab
+    name="pills-blue-tab"
+    style="pills">
+
+    <x-slot:headings>
+        <x-bladewind::tab.heading
+            name="pills-blue" active="true" label="Blue System Tab" />
+        <x-bladewind::tab.heading
+            name="inactive-pills-blue" label="The Other Tab" />
+    </x-slot:headings>
+
+    <x-bladewind::tab.body>
+        <x-bladewind::tab.content
+            name="pills-blue" active="true">...</x-bladewind::tab.content>
+        <x-bladewind::tab.content
+            name="inactive-pills-blue">...</x-bladewind::tab.content>
+    </x-bladewind::tab.body>
+
+</x-bladewind::tab>
+```
+
+## With Icons
+
+You can display icon prefixes in tab headings. This uses the BladewindUI [Icon component](/component/icon) so all Heroicons are supported. You can change how the icon looks by setting the `icon_css` attribute. The Heroicons outline icons are used by default. To use the solid icons instead, set `icon_type="solid"`. The `icon_dir` attribute allows you to specify which directory to pick your custom icons from.
+
+```blade
+<x-bladewind::tab name="tab-icon">
+    <x-slot name="headings">
+        <x-bladewind::tab.heading name="icon-blue" active="true"
+            icon="shopping-cart"
+            label="Shopping List" />
+        <x-bladewind::tab.heading name="icon-inactive"
+            label="Previous Purchases"
+            icon="shopping-bag" />
+        <x-bladewind::tab.heading name="icon-solid"
+            label="Solid Icon"
+            icon="shopping-bag"
+            icon_type="solid" />
+        <x-bladewind::tab.heading name="icon-solid-css" label="Icon Css Applied"
+            icon="fire"
+            icon_type="solid"
+            icon_css="!rounded-full !bg-orange-500 text-white size-6 p-1" />
+    </x-slot>
+    <x-bladewind::tab.body>
+        <x-bladewind::tab.content name="icon-blue" active="true">
+            <img src="/assets/images/lissete-laverde-z9Ropm8edsw-unsplash.jpg"
+                 alt="Picture by Lissete Laverde" />
+        </x-bladewind::tab.content>
+        <x-bladewind::tab.content name="icon-inactive">
+            <img src="/assets/images/sam-carter-JU1SVl4smHM-unsplash.jpg" alt="Picture by Sam Carter" />
+        </x-bladewind::tab.content>
+        <x-bladewind::tab.content name="icon-solid">
+            <img src="/assets/images/lissete-laverde-z9Ropm8edsw-unsplash.jpg" alt="Picture by Lissete Laverde" />
+        </x-bladewind::tab.content>
+    </x-bladewind::tab.body>
+</x-bladewind::tab>
+```
+
+## Attributes
+
+### Tab Group Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | _blank_ | Unique name to identify the tab component by in case there are multiple tab groups on the same page. |
+| style | simple | Choose a tab style. `simple` \| `system` \| `pills` |
+| headings | _blank_ | This is a slot that accepts one or more `<x-bladewind::tab.heading>` components. |
+| color | blue | There are nine colors to choose from. `primary` \| `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` \| `violet` \| `indigo` \| `fuchsia` |
+
+### Tab Heading Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | tab | Unique name to identify the tab heading. |
+| label | tab | Text to display as the tab heading. This is what the user clicks on to switch tabs. |
+| active | false | Specifies if the tab should be selected by default. `true` \| `false` |
+| disabled | false | Specifies if the tab should be disabled by default. Disabled tabs are faded out and do nothing when clicked on. `true` \| `false` |
+| url | default | By default tabs switch to their respective content. If you prefer your tab headings to load other urls when clicked on, set this attribute. This url is called using `location.href`. |
+| icon | null | Specify the icon prefix to display with the tab heading. |
+| icon_css | _blank_ | Additional CSS to modify the look of the icon. |
+| icon_dir | _blank_ | If you have your own custom icons you wish to use instead of Heroicons, specify the directory to load the icons from. |
+| icon_type | outline | Choose if you prefer outline or solid icons. `solid` \| `outline` |
+
+### Tab Body Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| class | _blank_ | Any additional Tailwind CSS classes to apply to the tab body container. This is the container all tab contents sit in. |
+
+### Tab Content Component Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | tab | This name must be the same as name given to this content's tab heading. |
+| active | false | Specifies if the tab should be selected by default. If this content's corresponding tab heading is active, this must also be set to active. `true` \| `false` |
+| class | _blank_ | Any additional Tailwind CSS classes to apply to the tab content container. Applies to a specific tab content. |
+
+## Full Example
+
+```blade
+<x-bladewind::tab name="red-tab" color="red" style="system">
+    <x-slot name="headings">
+
+        <x-bladewind::tab.heading
+            name="red"
+            active="true"
+            label="Active Red Tab" />
+
+        <x-bladewind::tab.heading
+            name="inactive-red"
+            disabled="true"
+            active="false"
+            url="/profile/settings"
+            label="The Other Tab" />
+
+    </x-slot>
+
+    <x-bladewind::tab.body class="p-2">
+
+        <x-bladewind::tab.content
+            name="red"
+            class="border border-gray-100"
+            active="true">...</x-bladewind::tab.content>
+
+        <x-bladewind::tab.content
+            name="inactive-red">...</x-bladewind::tab.content>
+
+    </x-bladewind::tab.body>
+
+</x-bladewind::tab>
+```

--- a/mcp/table.md
+++ b/mcp/table.md
@@ -1,0 +1,389 @@
+---
+title: Table Component
+component: x-bladewind::table
+url: /component/table
+---
+
+# Table
+
+Display tabular data. Supports both manually built tables and dynamic tables driven by an array. Dynamic tables support sorting, pagination, searching, grouping, action icons, and custom row clicks.
+
+## Basic Usage
+
+```blade
+<x-bladewind::table>
+    <x-slot name="header">
+        <th>Name</th>
+        <th>Department</th>
+        <th>Email</th>
+    </x-slot>
+    <tr>
+        <td>Michael Ocansey</td>
+        <td>Engineering</td>
+        <td>mike@bladewindui.com</td>
+    </tr>
+</x-bladewind::table>
+```
+
+## Styling Options
+
+```blade
+{{-- no gaps between rows --}}
+<x-bladewind::table has_border="true">...</x-bladewind::table>
+
+{{-- remove row dividers --}}
+<x-bladewind::table divided="false">...</x-bladewind::table>
+
+{{-- thin dividers --}}
+<x-bladewind::table divider="thin">...</x-bladewind::table>
+
+{{-- no hover effect --}}
+<x-bladewind::table has_hover="false">...</x-bladewind::table>
+
+{{-- compact padding --}}
+<x-bladewind::table compact="true">...</x-bladewind::table>
+
+{{-- striped rows --}}
+<x-bladewind::table striped="true">...</x-bladewind::table>
+
+{{-- celled (borders on all sides, like Excel) --}}
+<x-bladewind::table celled="true">...</x-bladewind::table>
+
+{{-- drop shadow --}}
+<x-bladewind::table has_shadow="true">...</x-bladewind::table>
+```
+
+## Totals Row (Double Underline)
+
+Wrap a totals `<tr>` in `<tfoot>` or add `class="double-underline"` to the cell above totals:
+
+```blade
+<x-bladewind::table>
+    <x-slot name="header">
+        <th>Item</th><th>Amount</th>
+    </x-slot>
+    <tr><td>Bags</td><td>$150.00</td></tr>
+    <tr><td>Shoes</td><td>$350.00</td></tr>
+    <tr>
+        <td class="double-underline">Total</td>
+        <td class="double-underline">$500.00</td>
+    </tr>
+</x-bladewind::table>
+```
+
+## Selectable Rows
+
+```blade
+<x-bladewind::table name="office_supplies" selectable="true">
+    <x-slot name="header"><th>Item</th><th>Qty</th></x-slot>
+    <tr data-id="1"><td>Stapler</td><td>3</td></tr>
+    <tr data-id="2"><td>Marker</td><td>6</td></tr>
+</x-bladewind::table>
+```
+
+Selected row IDs are stored in a hidden input with the table's `name`. Access via JavaScript: `domEl('input.office_supplies').value` returns a comma-separated list of selected `data-id` values.
+
+## Checkable Rows
+
+```blade
+<x-bladewind::table name="office_supplies" checkable="true">
+    <x-slot name="header"><th>Item</th><th>Qty</th></x-slot>
+    <tr data-id="1" data-name="Stapler"><td>Stapler</td><td>3</td></tr>
+    <tr data-id="2" data-name="Marker"><td>Marker</td><td>6</td></tr>
+</x-bladewind::table>
+```
+
+## Dynamic Data
+
+Pass a PHP array via `:data`. Column headings are automatically generated from array keys. Underscores in keys are replaced with spaces.
+
+```blade
+<x-bladewind::table :data="$staff" />
+
+{{-- or pass as JSON string --}}
+<x-bladewind::table data="{{ json_encode($staff) }}" />
+```
+
+### Excluding and Including Columns
+
+```blade
+<x-bladewind::table :data="$staff" exclude_columns="id, marital_status" />
+
+{{-- include_columns takes precedence over exclude_columns --}}
+<x-bladewind::table :data="$staff" include_columns="first_name, last_name, department" />
+```
+
+### Column Aliases
+
+```php
+$column_aliases = [
+    'id' => 'ref #',
+    'marital_status' => 'married?'
+];
+```
+
+```blade
+<x-bladewind::table :data="$staff" :column_aliases="$column_aliases" />
+```
+
+### Action Icons
+
+Pass an array of icon definitions. Each icon can have `icon`, `tip`, `color`, `icon_type`, `button_outline`, and `click`. In `click`, use `{key}` placeholders that are replaced with row values.
+
+```php
+$action_icons = [
+    [
+        'icon'  => 'chat-bubble-bottom-center-text',
+        'tip'   => 'send message',
+        'color' => 'green',
+        'icon_type' => 'solid',
+        'button_outline' => false,
+        'click' => "sendMessage('{first_name}')",
+    ],
+    [
+        'icon'  => 'pencil-square',
+        'click' => "redirect('/user/{id}')",
+    ],
+    [
+        'icon'  => 'trash',
+        'color' => 'red',
+        'click' => "deleteUser({id}, '{first_name}')",
+    ],
+];
+```
+
+```blade
+<x-bladewind::table
+    :data="$staff"
+    divider="thin"
+    :action_icons="$action_icons"
+    exclude_columns="id, marital_status" />
+```
+
+### Row Click Handler
+
+```blade
+<x-bladewind::table
+    :data="$staff"
+    onclick="goToProfile('/user/profile', '{first_name}', '{last_name}')" />
+```
+
+Rows with click handlers get `cursor-pointer`. The action icon cell does not inherit the row click.
+
+### No Data Message
+
+```blade
+<x-bladewind::table :data="$staff" no_data_message="The staff directory is empty" />
+
+{{-- with column headings visible when empty --}}
+<x-bladewind::table
+    :data="$no_staff"
+    :column_aliases="$column_aliases"
+    no_data_message="The staff directory is empty" />
+
+{{-- display as empty state component --}}
+<x-bladewind::table
+    :data="$no_staff"
+    no_data_message="The staff directory is empty"
+    message_as_empty_state="true"
+    button_label="add staff member" />
+```
+
+### Searchable
+
+```blade
+<x-bladewind::table
+    :data="$staff"
+    searchable="true"
+    search_placeholder="Find staff members by name..." />
+```
+
+Place the search bar in a custom container:
+
+```blade
+<div class="flex space-x-4 items-center bg-gray-100 px-3 rounded-lg">
+    <div class="put-search-here grow border bg-white rounded-md"></div>
+    <x-bladewind::datepicker range="true" />
+    <x-bladewind::button>Filter</x-bladewind::button>
+</div>
+
+<x-bladewind::table
+    :data="$staff"
+    searchable="true"
+    search_container="put-search-here" />
+```
+
+### Grouping Rows
+
+```blade
+<x-bladewind::table :data="$staff" groupby="department" />
+```
+
+### Sorting
+
+```blade
+<x-bladewind::table :data="$staff" sortable="true" />
+
+{{-- restrict sortable columns --}}
+<x-bladewind::table
+    :data="$staff"
+    sortable="true"
+    sortable_columns="first_name, last_name" />
+```
+
+### Pagination
+
+```blade
+<x-bladewind::table
+    :data="$staff"
+    paginated="true"
+    page_size="25"
+    show_row_numbers="true"
+    default_page="1" />
+```
+
+Pagination styles: `arrows` (default), `dropdown`, `numbers`.
+
+```blade
+<x-bladewind::table
+    :data="$staff"
+    paginated="true"
+    pagination_style="numbers"
+    show_total="true"
+    total_label="Showing :a to :b of :c records" />
+```
+
+Placeholders in `total_label`: `:a` = start row, `:b` = end row, `:c` = total records.
+
+### Custom Layout (Pagination with Manual Rows)
+
+```blade
+<x-bladewind::table
+    layout="custom"
+    :paginated="true"
+    :page_size="$page_size = 5"
+    :data="$users"
+    :default_page="$default_page = 1">
+
+    <x-slot:header>
+        <th>ID</th>
+        <th>User Details</th>
+        <th>Contact Details</th>
+    </x-slot:header>
+
+    <tbody>
+        @foreach($users as $user)
+            <tr {{ pagination_row($loop->iteration, $page_size, $default_page) }}>
+                <td>{{ $user['id'] }}</td>
+                <td>{{ $user['first_name'] }} {{ $user['last_name'] }}</td>
+                <td>{{ $user['email'] }}</td>
+            </tr>
+        @endforeach
+    </tbody>
+</x-bladewind::table>
+```
+
+`pagination_row($row_number, $page_size, $default_page)` generates the `data-id`, `data-page`, and `class="hidden"` attributes needed by the pagination widget.
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | random | Table name added to `class` for JS targeting |
+| striped | false | Stripe even rows. `true` \| `false` |
+| divided | true | Show row divider lines. `true` \| `false` |
+| divider | regular | Divider gap size. `regular` \| `thin` |
+| has_hover | false | Highlight rows on hover. `true` \| `false` |
+| has_shadow | true | Drop shadow. `true` \| `false` |
+| has_border | false | Outer border. `true` \| `false` |
+| compact | false | Reduce row padding. `true` \| `false` |
+| celled | false | Cell borders on all sides. `true` \| `false` |
+| transparent | false | Remove background colours. `true` \| `false` |
+| uppercasing | true | Uppercase column headings. `true` \| `false` |
+| header | _(slot)_ | Slot for `<th>` column headings |
+| :data | null | PHP array for dynamic table generation |
+| data | null | JSON-encoded array for dynamic table generation |
+| layout | auto | Table layout mode. `auto` \| `custom` |
+| exclude_columns | null | Comma-separated column keys to exclude |
+| include_columns | null | Comma-separated column keys to include (overrides `exclude_columns`) |
+| :action_icons | null | Array of action icon definitions per row |
+| actions_title | actions | Heading for the action icons column |
+| :column_aliases | [] | Array mapping array keys to display names |
+| onclick | _(blank)_ | JS function to call on row click (dynamic tables) |
+| groupby | _(blank)_ | Array key to group rows by |
+| searchable | false | Add a search field above the table. `true` \| `false` |
+| search_placeholder | Search table below... | Placeholder for the search input |
+| search_container | _(blank)_ | CSS class/id of element to render the search bar into |
+| no_data_message | No records to display | Message when no dynamic data exists |
+| message_as_empty_state | false | Show no-data message as Empty State component. `true` \| `false` |
+| image | empty-state.svg | Image for empty state |
+| heading | _(blank)_ | Heading for empty state |
+| button_label | _(blank)_ | Empty state call-to-action button label |
+| show_image | true | Show empty state image. `true` \| `false` |
+| selected_value | null | Comma-separated row IDs to pre-select |
+| selectable | false | Enable row selection. `true` \| `false` |
+| checkable | false | Enable row checkboxes. `true` \| `false` |
+| sortable | false | Enable column sorting. `true` \| `false` |
+| sortable_columns | [] | Comma-separated columns to make sortable |
+| paginated | false | Enable pagination. `true` \| `false` |
+| pagination_style | arrows | Pagination controls style. `arrows` \| `dropdown` \| `numbers` |
+| page_size | 25 | Rows per page |
+| default_page | 1 | Initial page to display |
+| show_row_numbers | false | Show row numbers as first column. `true` \| `false` |
+| show_total | true | Show pagination total label. `true` \| `false` |
+| show_page_number | true | Show current page number (arrows style). `true` \| `false` |
+| show_total_pages | false | Show current/total page fraction. `true` \| `false` |
+| total_label | Showing :a to :b of :c records | Pagination total label format |
+| limit | null | Cap the total number of rows displayed |
+| nonce | null | Nonce value for Content Security Policy |
+
+## Full Example
+
+```blade
+<x-bladewind::table
+    striped="true"
+    divided="true"
+    divider="thin"
+    has_shadow="true"
+    has_border="true"
+    compact="true"
+    transparent="true"
+    searchable="false"
+    search_placeholder=""
+    name="staff-table"
+    :data="$data"
+    :column_aliases="$column_aliases"
+    include_columns="first_name, last_name, email"
+    exclude_columns="id,picture"
+    :action_icons="$action_icons"
+    actions_title="actions"
+    no_data_message="The staff directory is empty"
+    message_as_empty_state="true"
+    button_label="add staff member"
+    heading="No Staff"
+    groupby="department"
+    selected_value="2,3,4"
+    onclick="alert('add a staff')"
+    sortable="false"
+    paginated="false"
+    pagination_style="arrows"
+    page_size="25"
+    show_row_numbers="false"
+    show_total="true"
+    limit="40"
+    layout="custom"
+    total_label="Showing :a to :b of :c records"
+    has_hover="true">
+
+    <x-slot name="header">
+        <th>Name</th>
+        <th>Department</th>
+    </x-slot>
+
+    <tr>
+        <td>...</td>
+        <td>...</td>
+    </tr>
+
+</x-bladewind::table>
+```

--- a/mcp/tag.md
+++ b/mcp/tag.md
@@ -1,0 +1,218 @@
+---
+title: Tag Component
+component: x-bladewind::tag
+url: /component/tag
+---
+
+# Tag
+
+Tags, sometimes referred to as labels allow you to logically group items or indicate statuses of items. You can also use tags to list selections. They are very simple to use.
+
+```blade
+<x-bladewind::tag label="pending" />
+```
+
+## Faint Coloured
+
+The BladewindUI tag component allows you to specify different colours. The tags by default are faint in colour with blue being the default colour. There are nine colour options to pick from.
+
+```blade
+<x-bladewind::tag label="pending" color="color-name" />
+```
+
+Available colours: `primary` `red` `yellow` `green` `blue` `pink` `cyan` `orange` `gray` `purple` `violet` `indigo` `fuchsia`
+
+## Dark Coloured
+
+Dark colours in this case have nothing to do with dark mode. These are just a deeper shade of the tag colours. You can get darker shaded tags by setting `shade="dark"`.
+
+```blade
+<x-bladewind::tag label="pending" shade="dark" color="color-name" />
+```
+
+## With Close Icons
+
+Tags can also have close icons. That will be useful if you use tags to display user selections and want a way to remove a user's selection from the list. By default tags do not show the close icon. To activate close icons, set `can_close="true"`. The default action when the close icon is clicked is to remove the tag that was clicked.
+
+```blade
+<x-bladewind::tag label="pending"
+    can_close="true" />
+
+<x-bladewind::tag label="pending"
+    can_close="true"
+    color="pink" />
+```
+
+To run your own code when the close icon is clicked, provide a javascript function to the `onclick` attribute. You may need to use the `id` attribute to provide unique identifiers for your tags. By default each tag has a randomly generated `id` prefixed with `bw-` to prevent numeric only IDs from breaking. You can turn off the prefixing of IDs by setting `add_id_prefix="false"`.
+
+```blade
+<x-bladewind::tag
+    label="marketing"
+    can_close="true"
+    add_id_prefix="false"
+    id="a1001"
+    onclick="alert('you clicked on '+ dom_el('#a1001').innerText)" />
+
+<x-bladewind::tag
+    label="accounting"
+    can_close="true"
+    color="pink"
+    class="a1002"
+    onclick="alert('you clicked on '+ dom_el('.a1002').innerText)" />
+```
+
+## Tiny Tags
+
+Sometimes you need to display tags as hints. For example in a menu bar you may want users to know which features are new by displaying a colourful but tiny _new_ tag next to each new menu item. Setting the `tiny="true"` attribute will serve such a purpose. Specifying this attribute on a `x-bladewind::tags` component will apply the size to all tags defined within the component. However, specifying the attribute on a `x-bladewind::tag` component will only apply it to that single tag.
+
+```blade
+<x-bladewind::tag label="just added" tiny="true" color="pink" />
+```
+
+```blade
+<x-bladewind::tag label="new" tiny="true" color="purple"
+    shade="dark"
+    uppercasing="false"/>
+```
+
+## Rounded Tags
+
+There are cases where you have a rounded elements theme running through your app and will prefer to have rounded tags. To make tags rounded set `rounded="true"`.
+
+```blade
+<x-bladewind::tag label="pending"
+    rounded="true" />
+
+<x-bladewind::tag label="pending"
+    can_close="true"
+    rounded="true"
+    color="pink" />
+```
+
+## Outline Tags
+
+What if you prefer to have no background colours on your tags — just a border outline with your chosen colour. Simply set `outline="true"`. The outline border colour is also affected by the shade you set. So light shades have a lighter outline. Dark shades have a darker outline.
+
+```blade
+<x-bladewind::tag label="pending" outline="true" color="pink" />
+
+<x-bladewind::tag label="pending" can_close="true"
+    outline="true"
+    color="pink"
+    shade="dark" />
+```
+
+## Selectable Tags
+
+Selectable tags allow you to use tags in forms. You can think of them in this case as a different kind of checkboxes. Tags automatically become selectable when you specify the `name` and `value` attributes.
+
+Hidden input fields are created for distinct tag names. Values of the selected tags are then written to the hidden input fields making them accessible when the form is submitted. For example: if we have 3 tags with the name **location**, this input field will be created `<input type="hidden" name="location" />`. When any location is selected, the value will be written into the hidden location input field. Multiple values are written as a comma separated list.
+
+Note the tags are wrapped in a parent `<x-bladewind::tags>...</x-bladewind::tags>` component. You can restrict how many tags can be selected from the list using the `max` attribute on the `tags` component. Where a `max` attribute is used, it is necessary to define the `error_message` and `error_heading` attributes. This is the message to be displayed if a user tries to select more than the maximum tags allowed.
+
+```blade
+<x-bladewind::tags
+    color="orange"
+    name="stack"
+    required="true"
+    max="3"
+    error_message="You can select only up to 3 tech stacks"
+    error_heading="Check selection!">
+
+    <x-bladewind::tag label="laravel" value="laravel" />
+    <x-bladewind::tag label="javascript" value="js" />
+    <x-bladewind::tag label="node js" value="node js" />
+    <x-bladewind::tag label="tailwindcss" value="tailwind" />
+    <x-bladewind::tag label="c-sharp" value="cs" />
+
+</x-bladewind::tags>
+```
+
+To have values pre-selected by default (e.g., in edit mode), use the `selected_value` attribute with a comma-separated list of values:
+
+```blade
+<x-bladewind::tags
+    color="red"
+    name="fridays"
+    selected_value="hangout,club,sleep">
+
+    <x-bladewind::tag label="hangout with friends" value="hangout" />
+    <x-bladewind::tag label="go clubbing" value="club" />
+    <x-bladewind::tag label="watch movies" value="movies" />
+    <x-bladewind::tag label="just chill" value="chill" />
+    <x-bladewind::tag label="sleeeeep" value="sleep" />
+
+</x-bladewind::tags>
+```
+
+## Attributes
+
+### Tags Component
+
+Only used when defining selectable tags.
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | null | The name used when defining selectable tags. This name can be retrieved when the form is submitted. |
+| color | blue | There are nine colors to choose from. `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` |
+| max | null | How many tags can be selected. By default there is no limit. |
+| required | false | Determines if selectable tags are required when displayed in a form. `true` \| `false` |
+| selected_value | _empty string_ | In edit mode you will want selected tags to be highlighted by default. Set the values as a comma separated list. |
+| error_heading | Error | Heading to display in the notification when displaying an error message. |
+| error_message | _empty string_ | Message to display when `max` is set and user selection exceeds the max allowed. |
+| rounded | false | Determines if the tag is fully rounded or not. By default tags have a very subtle roundness. `true` \| `false` |
+| tiny | false | Determines if the size of all the tags in the group is tiny. There are just two sizes, tiny and regular. `true` \| `false` |
+| uppercasing | true | Determines if the text for all the tags in the group is uppercased. `true` \| `false` |
+| shade | faint | Determines if the tags should have a faint or darker color shade. `faint` \| `dark` |
+| outline | false | Determines if the tag is only outlined with `color` above. Outline tags have no background colour. `true` \| `false` |
+| class | space-x-2 space-y-2 | Any additional CSS you wish to add to the tags container. |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. |
+
+### Tag Component
+
+| Attribute | Default | Description |
+|---|---|---|
+| label | _blank_ | The text to display on the tag. |
+| color | blue | There are nine colors to choose from. `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` |
+| shade | faint | Determines if the tags should have a faint or darker color shade. `faint` \| `dark` |
+| can_close | false | Determines if the tag should display a close icon or not. `true` \| `false` |
+| id | uniqid() | Unique id for the tag. By default tag IDs have a prefix of `bw-`. |
+| add_id_prefix | true | Determines if the `bw-` prefix should be added to tag IDs. `true` \| `false` |
+| rounded | false | Determines if the tag is fully rounded or not. `true` \| `false` |
+| outline | false | Determines if the tag is only outlined with `color` above. `true` \| `false` |
+| tiny | false | Determines if the tag size is tiny. `true` \| `false` |
+| uppercasing | true | Determines if the tag text is all uppercase. `true` \| `false` |
+| onclick | _blank_ | Javascript function to execute when the close icon is clicked. |
+| class | bw-tag | Any additional CSS you wish to add. |
+
+## Full Example
+
+```blade
+<x-bladewind::tags
+    name="stack"
+    color="orange"
+    required="true"
+    rounded="true"
+    max="3"
+    tiny="false"
+    uppercasing="false"
+    selected_value="laravel,js"
+    error_message="You can select only up to 3 tech stacks"
+    error_heading="Check selection!">
+
+    <x-bladewind::tag
+        label="accounting"
+        can_close="true"
+        color="pink"
+        class="a1002"
+        id="a1002"
+        rounded="true"
+        outline="true"
+        add_id_prefix="false"
+        shade="dark"
+        tiny="false"
+        uppercasing="false"
+        onclick="alert('you clicked on '+ dom_el('.a1002').innerText)" />
+
+</x-bladewind::tags>
+```

--- a/mcp/textarea.md
+++ b/mcp/textarea.md
@@ -1,0 +1,100 @@
+---
+title: Textarea Component
+component: x-bladewind::textarea
+url: /component/textarea
+---
+
+# Textarea
+
+Displays a textarea. By default the textarea is displayed with three rows. You can increase the number of rows by setting the `rows` attribute. Example, `rows="5"`.
+
+## Add Placeholder Text
+
+```blade
+<x-bladewind::textarea placeholder="Comment" />
+```
+
+## With Labels
+
+You can display the BladewindUI textarea with labels. Labels present themselves as placeholders but jump to the top border of the textarea when that field has focus. This is a nice way to build compact looking forms without having form labels in the way. If you prefer to create and style your own form labels, simply ignore the `label` attribute and use the `placeholder` attribute instead.
+
+```blade
+<x-bladewind::textarea label="Comment" />
+```
+
+## Required Fields
+
+This either adds a red asterisk sign to the placeholder text or a red star to the label of the textarea field.
+
+```blade
+<x-bladewind::textarea required="true" label="Comment" />
+```
+
+See component/textarea documentation on [Validating Required Fields](https://bladewindui.com/component/textbox#validate).
+
+## Events
+
+You can append any of the available HTML event attributes (*onclick, onblur, onfocus, onmouseover, onmouseout, onkeyup, onkeydown* etc) to the component, just like you would to a regular `<textarea ...` tag. The border of the textarea below turns red onfocus and to gray onblur.
+
+```blade
+<x-bladewind::textarea
+    name="events"
+    label="Comment"
+    required="true"
+    onfocus="changeCss('.events', '!border-2,!border-red-400')"
+    onblur="changeCss('.events', '!border-2,!border-red-400', 'remove')">
+</x-bladewind::textarea>
+```
+
+## Simple Toolbar
+
+The textarea can display simple toolbar by setting `toolbar="true"`. The toolbar assets are included from the [Quill website](https://quilljs.com).
+
+```blade
+<x-bladewind::textarea
+    placeholder="Comment" toolbar="true"></x-bladewind::textarea>
+```
+
+The formatting options listed on the toolbar are `bold`, `italic`, `underline`, `align`, `indent`, `link`, `color`, `background`, `list`, `image`, `blockquote`, `code-block` and `clean`. To remove some of the formatting options from the toolbar, set the `except` attribute and provide a comma separated list of the formatting options to remove.
+
+```blade
+<x-bladewind::textarea
+    except="align, indent, color, background"
+    placeholder="Comment" toolbar="true"></x-bladewind::textarea>
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| `name` | `textarea-uniqid()` | Unique name to identify the textarea element by. Useful for retrieving value from the textarea when it is submitted in a form. The component by default uses a random name prefixed with 'textarea-'. |
+| `label` | *blank* | Label that describes the textarea element. Example: Full name |
+| `error_message` | *blank* | Error message to display when field is required but blank. |
+| `error_heading` | `Error` | Error heading to display in notification component when field is required but blank. This is used when `show_error_inline=true`. |
+| `show_error_inline` | `false` | Specifies if the error message is displayed inline (beneath the field) or in a notification component. `true` `false` |
+| `required` | `false` | Specifies if the textarea element is required or not. When required, a red asterisk is displayed next to the placeholder or label. `true` `false` |
+| `add_clearing` | `true` | Specifies if an 8px margin should be added to the bottom of the element. This ensures your form fields are evenly spaced by default. `true` `false` |
+| `toolbar` | `false` | Display a simple [Quill](https://quilljs.com) toolbar on top of the textarea. `true` `false` |
+| `except` | *blank* | Define formatting options to exclude from the toolbar. Accepts a comma separated list of options. |
+| `placeholder` | *blank* | Placeholder text to display in the textarea element. |
+| `rows` | `3` | Specifies the height of the textarea in rows. Can be any positive whole number. This is ignored when in toolbar mode. |
+| `selected_value` | *blank* | Default value to display in the textarea element. Useful when in edit mode. |
+| `nonce` | `null` | Used when implementing context security policies and require to pass a nonce to inline scripts. For convenience, you can set your `nonce` value in the `config/bladewind.php` file under the "script" key. This value will be used everywhere nonce is required. |
+
+## Full Example
+
+```blade
+<x-bladewind::textarea
+    name="message"
+    label="Enter message"
+    placeholder=""
+    add_clearing="false"
+    required="true"
+    toolbar="true"
+    except="align, bold, italic"
+    show_error_inline="false"
+    error_heading="Error"
+    error_message="A comment is required"
+    rows="5"
+    selected_value="" /></x-bladewind::textarea>
+```

--- a/mcp/theme-switcher.md
+++ b/mcp/theme-switcher.md
@@ -1,0 +1,47 @@
+---
+title: Theme Switcher Component
+component: x-bladewind::theme-switcher
+url: /component/theme-switcher
+---
+
+# Theme Switcher
+
+It is common practice these days to build web sites/apps that allow users to switch between dark and light modes. This is one of those Bladewind components that takes away the headache of building your own theme switching mechanism.
+
+There can be only one theme switcher on a page. The Bladwind docs uses the theme switcher in the top right corner of the website.
+
+```blade
+<x-bladewind::theme-switcher />
+```
+
+There are a few customizations available. See the full list of attributes below. Also refer to our [dark mode customization page](/customize#dark-mode) for more.
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| `icon_right` | `true` | Should the icons be placed on the left or right of the text. `true` `false` |
+| `icon_type` | *blank* | By default the outline icons from Heroicons are used. You can use the solid icons if you prefer. See details about this on the [Icon component](/component/icon#solid-icons) page. |
+| `icon_dir` | *blank* | If you plan on using custom icons instead of the defaults from Heroicons, specify the directory these icons will be loaded from. See details about this on the [Icon component](/component/icon#custom-dir) page. |
+| `light_icon` | `sun` | The icon displayed next to the word, Light. Use any icon from Heroicons or your [custom icons](/component/icon#custom-dir). |
+| `dark_icon` | `moon` | The icon displayed next to the word, Dark. Use any icon from Heroicons or your [custom icons](/component/icon#custom-dir). |
+| `system_icon` | `computer-desktop` | The icon displayed next to the word, System. Use any icon from Heroicons or your [custom icons](/component/icon#custom-dir). |
+| `light_text` | `Light` | Word displayed next to the light icon. This is provided as an option to make this translatable at your app level. |
+| `dark_text` | `Dark` | Word displayed next to the dark icon. This is provided as an option to make this translatable at your app level. |
+| `system_text` | `System` | Word displayed next to the system icon. This is provided as an option to make this translatable at your app level. Some people prefer to use 'Auto'. |
+| `nonce` | `null` | Used when implementing context security policies and require to pass a nonce to inline scripts. For convenience, you can set your `nonce` value in the `config/bladewind.php` file under the "script" key. This value will be used everywhere nonce is required. |
+
+## Full Example
+
+```blade
+<x-bladewind::theme-switcher
+    icon_right="false"
+    icon_dir="assets/icons"
+    icon_type="solid"
+    light_text="Light Mode"
+    light_icon="bulb"
+    dark_text="Dark Mode"
+    dark_icon="sun-shades"
+    system_text="Auto Mode"
+    system_icon="day-night" />
+```

--- a/mcp/timeline.md
+++ b/mcp/timeline.md
@@ -1,0 +1,188 @@
+---
+title: Timeline Component
+component: x-bladewind::timeline
+url: /component/timeline
+---
+
+# Timeline
+
+Display information in chronological order using a feed-like view. The `date` attribute accepts any string. Two components work together: `x-bladewind::timelines` (optional wrapper) and `x-bladewind::timeline` (individual items).
+
+## Basic Usage
+
+```blade
+<x-bladewind::timeline date="10 days ago" content="You signed up" />
+<x-bladewind::timeline date="8 days ago" content="Customer rep assigned" />
+<x-bladewind::timeline date="8 days ago" content="Customer rep called" />
+<x-bladewind::timeline content="Account is being reviewed" />
+<x-bladewind::timeline content="Account activated" />
+```
+
+## Bigger Anchors
+
+```blade
+<x-bladewind::timeline anchor="big" date="10 days ago" content="You signed up" />
+```
+
+## Completed State
+
+Set `completed="true"` to show filled circles. When `anchor="big"`, a checkmark is also displayed.
+
+```blade
+<x-bladewind::timeline completed="true" date="10 days ago" content="You signed up" />
+<x-bladewind::timeline completed="true" anchor="big" date="8 days ago" content="Customer rep assigned" />
+```
+
+## Stacked Timelines
+
+Use `x-bladewind::timelines` as a wrapper to apply shared attributes to all children. When `stacked="true"`, dates appear above content rather than beside it.
+
+```blade
+<x-bladewind::timelines stacked="true">
+
+    <x-bladewind::timeline date="just now" content="database server restarted" />
+
+    <x-bladewind::timeline date="30 minutes ago">
+        <x-slot:content>
+            <a>2 endpoints</a> are failing on bladewindui-data EC2 bucket.
+            You may want to login and check the logs
+        </x-slot:content>
+    </x-bladewind::timeline>
+
+    <x-bladewind::timeline date="Yesterday" content="Data recovery completed with 2 errors" />
+
+</x-bladewind::timelines>
+```
+
+Set `completed="true"` on the wrapper to mark all items as complete:
+
+```blade
+<x-bladewind::timelines stacked="true" completed="true" anchor="big">
+    <x-bladewind::timeline date="just now" content="database server restarted" />
+    ...
+    {{-- override for a specific item --}}
+    <x-bladewind::timeline date="Yesterday" content="Data recovery" completed="false" />
+</x-bladewind::timelines>
+```
+
+## Anchor Icons and Avatars
+
+Icons and avatars only work when `anchor="big"`.
+
+```blade
+{{-- per-item icons --}}
+<x-bladewind::timelines anchor="big" completed="true">
+    <x-bladewind::timeline date="10 days ago" content="You signed up" icon="bell-alert" />
+    <x-bladewind::timeline date="8 days ago" content="Customer rep assigned" icon="bolt" />
+    <x-bladewind::timeline content="Account is being reviewed" icon="key" completed="false" />
+</x-bladewind::timelines>
+
+{{-- avatars --}}
+<x-bladewind::timelines anchor="big">
+    <x-bladewind::timeline date="10 days ago" content="You signed up" avatar="/assets/images/pic1.jpg" />
+    <x-bladewind::timeline date="8 days ago" content="Customer rep assigned" avatar="/assets/images/pic2.jpg" />
+</x-bladewind::timelines>
+```
+
+## Positioning
+
+Only `x-bladewind::timelines` can be positioned. Default is `center`.
+
+```blade
+<x-bladewind::timelines position="left" anchor="big">
+    ...
+</x-bladewind::timelines>
+```
+
+## Left Alignment (Stacked Only)
+
+In a centered stacked timeline, individual items can be flipped to the left:
+
+```blade
+<x-bladewind::timelines stacked="true">
+    <x-bladewind::timeline date="just now" content="server restarted" align_left="true" />
+    <x-bladewind::timeline date="30 minutes ago" content="endpoints failing" />
+</x-bladewind::timelines>
+```
+
+## No Trailing Line
+
+Add `last="true"` to the last item to remove the trailing connector line.
+
+```blade
+<x-bladewind::timeline content="Account activated" last="true" />
+```
+
+## Colours
+
+```blade
+<x-bladewind::timeline date="10 days ago" content="You signed up" color="pink" completed="true" />
+<x-bladewind::timeline date="8 days ago" content="Customer rep assigned" color="orange" />
+<x-bladewind::timeline content="Account is being reviewed" color="purple" />
+```
+
+Available colours: `blue` `red` `yellow` `green` `purple` `pink` `orange` `black` `cyan` `violet` `indigo` `fuchsia`
+
+## Attributes
+
+### `x-bladewind::timelines` (wrapper)
+
+| Attribute | Default | Description |
+|---|---|---|
+| stacked | false | Stack dates above content. `true` \| `false` |
+| completed | false | Mark all items as completed. `true` \| `false` |
+| anchor | small | Anchor size. `small` \| `big` |
+| anchor_css | _(blank)_ | Additional TailwindCSS for the anchor |
+| icon | _(blank)_ | Heroicons icon name for all anchors |
+| icon_css | _(blank)_ | Additional TailwindCSS for the icon |
+| date_css | _(blank)_ | Additional TailwindCSS for dates |
+| position | center | Group position in parent. `left` \| `center` |
+| color | blue | Colour for all items in the group |
+
+### `x-bladewind::timeline` (item)
+
+| Attribute | Default | Description |
+|---|---|---|
+| date | _(blank)_ | Date string displayed left of or above content |
+| date_css | _(blank)_ | Additional TailwindCSS for the date |
+| content | _(blank)_ | Also `label`. The event content or description |
+| completed | false | Mark this item as completed. `true` \| `false` |
+| stacked | false | Stack date above content. `true` \| `false` |
+| anchor | small | Anchor size. `small` \| `big` |
+| anchor_css | _(blank)_ | Additional TailwindCSS for the anchor |
+| icon | _(blank)_ | Heroicons icon name for this item's anchor |
+| icon_css | _(blank)_ | Additional TailwindCSS for the icon |
+| avatar | _(blank)_ | Image URL to use as the anchor |
+| avatar_css | _(blank)_ | Additional TailwindCSS for the avatar |
+| last | false | Remove the trailing connector line. `true` \| `false` |
+| align_left | false | Flip a stacked item to left alignment. `true` \| `false` |
+| color | blue | Colour for this item |
+
+## Full Example
+
+```blade
+<x-bladewind::timelines
+    stacked="true"
+    anchor="big"
+    anchor_css="pl-9"
+    color="pink"
+    icon="briefcase"
+    icon_css="pl-9"
+    date_css="tracking-wider"
+    position="left"
+    completed="true">
+
+    <x-bladewind::timeline
+        stacked="true"
+        anchor="big"
+        color="pink"
+        icon="briefcase"
+        date="9 days ago"
+        date_css="tracking-wider"
+        align_left="true"
+        avatar="/assets/images/me.jpg"
+        content="I am a timeline"
+        completed="true" />
+
+</x-bladewind::timelines>
+```

--- a/mcp/timepicker.md
+++ b/mcp/timepicker.md
@@ -1,0 +1,99 @@
+---
+title: Timepicker Component
+component: x-bladewind::timepicker
+url: /component/timepicker
+---
+
+# Timepicker
+
+Display a time picker in two styles: `popup` (default) or `inline`.
+
+## Basic Usage
+
+```blade
+{{-- popup (default) --}}
+<x-bladewind::timepicker />
+
+{{-- inline --}}
+<x-bladewind::timepicker style="inline" />
+```
+
+## Time Formats
+
+Default is 12-hour format (1–12 with AM/PM). Set `format="24"` for 24-hour format (00–23, no AM/PM).
+
+```blade
+<x-bladewind::timepicker format="24" />
+<x-bladewind::timepicker style="inline" format="24" />
+```
+
+## Required Fields
+
+```blade
+<x-bladewind::timepicker required="true" />
+<x-bladewind::timepicker label="HH:MM" required="true" />
+```
+
+## Default Values
+
+```blade
+{{-- 12-hour format --}}
+<x-bladewind::timepicker selected_value="3:25PM" />
+
+{{-- 24-hour format --}}
+<x-bladewind::timepicker selected_value="03:25" format="24" />
+
+{{-- inline with pre-selected time --}}
+<x-bladewind::timepicker style="inline" selected_value="3:25PM" />
+
+{{-- inline, 24h, required, pre-selected --}}
+<x-bladewind::timepicker
+    required="true"
+    style="inline"
+    format="24"
+    selected_value="03:25" />
+```
+
+## Form Values
+
+Specify a `name` to retrieve the value on form submission. A random name is generated if omitted.
+
+```php
+// format="12" (default)
+$request->event_time; // outputs: 1:25PM
+
+// format="24"
+$request->event_time; // outputs: 01:25
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | bw-timepicker | Name submitted with the form |
+| style | popup | Display style. `popup` \| `inline` |
+| format | 12 | Time format. `12` \| `24` |
+| selected_value | _(blank)_ | Default pre-selected time (edit mode) |
+| label | _(blank)_ | Input label (popup style only) |
+| placeholder | HH:MM | Input placeholder (popup style only) |
+| hour_label | HH | Label for the hour dropdown |
+| minute_label | MM | Label for the minute dropdown |
+| format_label | -- | Label for the time format dropdown (inline style only) |
+| required | false | Append asterisk to placeholder. `true` \| `false` |
+| nonce | null | Nonce value for Content Security Policy |
+
+## Full Example
+
+```blade
+<x-bladewind::timepicker
+    name="start_time"
+    format="24"
+    required="false"
+    hour_label="hh"
+    minute_label="mm"
+    format_label="AM/PM"
+    placeholder="Start Time"
+    label="Start Time"
+    style="inline"
+    selected_value="12:35AM" />
+```

--- a/mcp/toggle.md
+++ b/mcp/toggle.md
@@ -1,0 +1,116 @@
+---
+title: Toggle Component
+component: x-bladewind::toggle
+url: /component/toggle
+---
+
+# Toggle
+
+Display a toggle input. Under the hood, the toggle component is a checkbox spiced up nicely.
+
+```blade
+<x-bladewind::toggle />
+```
+
+You can display the toggle component with a label that can be positioned either on the left or right of the component. The default position is left but can easily be flipped to the right by setting the attribute `label_position="right"`. Clicking on the label toggles the component.
+
+```blade
+<x-bladewind::toggle label="Send me quarterly newsletters" />
+```
+
+```blade
+<x-bladewind::toggle
+    label="Send me quarterly newsletters"
+    label_position="right" />
+```
+
+The toggle component by default is displayed as an inline-flex element to enable you sit multiple toggles side by side. If you prefer your toggles to fill up their parent containers and be justified with the label, set `justified="true"`.
+
+```blade
+<x-bladewind::toggle
+    label="Send me quarterly newsletters"
+    justified="true" />
+```
+
+## Thin and Thicker Bars
+
+The toggle component can have a thinner bar like is seen on most Android devices and thicker bar as seen on iOS. Set `bar="thin"` or `bar="thicker"`. The default bar is set at `bar="thick"`.
+
+```blade
+<x-bladewind::toggle
+    label="Send me quarterly newsletters"
+    bar="thin" />
+```
+
+```blade
+<x-bladewind::toggle
+    label="Send me quarterly newsletters"
+    bar="thicker" />
+```
+
+## Checked and Disabled
+
+The toggle component can be checked and/or disabled by default. To check the component set `checked="true"`. To mark the toggle as disabled, set `disabled="true"`.
+
+```blade
+<x-bladewind::toggle
+    checked="true"
+    label="I am checked at birth" />
+```
+
+```blade
+<x-bladewind::toggle
+    disabled="true"
+    label="I am checked at birth" />
+```
+
+```blade
+<x-bladewind::toggle
+    checked="true" disabled="true"
+    label="I am checked at birth" />
+```
+
+## Different Colours
+
+There are nine colours to pick from when the toggle component is active or checked. To set your preferred colour set the `color` attribute.
+
+```blade
+<x-bladewind::toggle color="red" />
+<x-bladewind::toggle color="yellow" />
+<x-bladewind::toggle color="green" />
+<x-bladewind::toggle color="pink" />
+<x-bladewind::toggle color="cyan" />
+<x-bladewind::toggle color="gray" />
+<x-bladewind::toggle color="purple" />
+<x-bladewind::toggle color="orange" />
+<x-bladewind::toggle color="blue" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | `bw-toggle` | Unique name to identify the component and access its value when submitted. |
+| label | _blank_ | Clickable label to display next to the toggle component. |
+| label_position | `left` | Specifies where the label should be positioned. `left` \| `right` |
+| disabled | `false` | Specifies if the toggle is disabled or not. `true` \| `false` |
+| checked | `false` | Specifies if the toggle is checked or not. `true` \| `false` |
+| color | `primary` | There are nine colors to choose from. `red` \| `yellow` \| `green` \| `blue` \| `pink` \| `cyan` \| `purple` \| `gray` \| `orange` |
+| justified | `false` | Specifies if the label and toggle are spread out to evenly fill up the parent container. `true` \| `false` |
+| bar | `thick` | Specifies the size for the slider bar. `thin` \| `thick` \| `thicker` |
+| onclick | `javascript:void(0)` | Javascript function to call when the toggle is clicked. This is fired both when the toggle is checked or not. You will need to programmatically determine if the toggle is checked or not. |
+
+## Full Example
+
+```blade
+<x-bladewind::toggle
+    color="purple"
+    label="Send me quarterly newsletters"
+    label_position="right"
+    name="subscribe"
+    justified="false"
+    disabled="false"
+    bar="thin"
+    checked="false"
+    onclick="alert('hey there')" />
+```

--- a/mcp/tooltip.md
+++ b/mcp/tooltip.md
@@ -1,0 +1,44 @@
+---
+title: Tooltip Component
+component: x-bladewind::tooltip
+url: /component/tooltip
+---
+
+# Tooltip
+
+Display a tooltip. This is technically not a component.
+
+```blade
+<x-bladewind.spinner />
+```
+
+```blade
+<x-bladewind.spinner size="medium" />
+```
+
+```blade
+<x-bladewind.spinner size="big" />
+```
+
+```blade
+<x-bladewind.spinner size="xl" />
+```
+
+```blade
+<x-bladewind.spinner size="omg" />
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| size | `small` | `small` \| `medium` \| `big` \| `xl` \| `omg` |
+| css | `bw-spinner` | Any additional CSS you wish to add. |
+
+## Full Example
+
+```blade
+<x-bladewind.spinner
+    size="medium"
+    css="m-0" />
+```

--- a/mcp/verification-code.md
+++ b/mcp/verification-code.md
@@ -1,0 +1,243 @@
+---
+title: Verification Code Component
+component: x-bladewind::code
+url: /component/verification-code
+---
+
+# Verification Code
+
+Displays a set of input fields to accept a verification code from a user. It is common place on websites these days to send verification codes via email or mobile. These codes range from four to six digits. The default number of digits displayed by the component is four (4). In this documentation, we may interchange the words PIN, PIN code and verification code. We mean the same thing.
+
+## Basic Usage
+
+```blade
+<x-bladewind::code  />
+```
+
+```blade
+<x-bladewind::code size="big"  />
+```
+
+The verification code component allows you to specify how many boxes you want to display by specifying the `total_digits` attribute. There is no restriction on the maximum value you can specify. In a finance app, you could use this to collect account numbers.
+
+```blade
+<x-bladewind::code total_digits="5"  />
+```
+
+If you don't want the code being entered to be visible, set the `mask="true"` attribute.
+
+```blade
+<x-bladewind::code mask="true"  />
+```
+
+## Access the Verification Code
+
+What happens after the user enters their verification code? The component creates a hidden input field with the name that was passed as the `name` attribute.
+
+```blade
+<x-bladewind::code name="pin_code"  />
+```
+
+The above will create the input fields for the verification codes and create the hidden input below:
+
+```blade
+<input type="hidden" name="pin_code" class="pin_code ..." id="pin_code"  />
+```
+
+You can access the value of `pin_code` either via Javascript or via PHP if you intend to post it in a form to your backend. The `onverify` attribute allows you to specify a function that should be called when the user has entered a value into the last verification code field. This should just be the function name without parentheses and parameters. If you wish to call `verifyPin()` after the user enters the code, just type `onverify="verifyPin"`. The component passes the code entered by the user to your function, as well as the name of the component, so your function declaration needs to expect one or two parameters.
+
+```blade
+<x-bladewind::code onverify="checkPin" />
+
+<script>
+    checkPin = (code) => {
+        alert(`You entered: ${code}`);
+    }
+</script>
+```
+
+## Clear PIN/Code
+
+There are cases where you will want to clear the verification code input field probably because the user entered a wrong pin and you want them to try entering the pin again. `clearPin(name)` is a Bladewind helper function that easily lets you reset your verification codes.
+
+```blade
+<x-bladewind::code name="clear_me" onverify="checkPinAndClear" />
+```
+
+```blade
+<script>
+    checkPinAndClear = (code) => {
+        if(code !== 2024) {
+            clearPin('clear_me');
+            showNotification('Wrong Code', 'Please enter your code again', 'error');
+        }
+    }
+</script>
+```
+
+## Displaying Errors
+
+The verification code component comes with a hidden field that has the error message to display when validation fails for the code the user entered. To allow for translatable messages, the error message is defined on the component using the `error_message` attribute.
+
+```blade
+<x-bladewind::code
+    name="pcode"
+    error_message="Yoh! check your code"
+    onverify="checkPinShowError" />
+```
+
+```blade
+<script>
+    checkPinShowError = (code) => {
+        if( code !== 2024) {
+            clearPin('pcode');
+            showPinError('pcode');
+        }
+    }
+</script>
+```
+
+The error message is displayed by invoking the Javascript helper function `showPinError(name)`. It accepts the name provided to the code component as a parameter. The error message is automatically hidden by calling the `hidePinError(name)` Javascript helper function. The second parameter to this function is what controls the automatic hiding of the error message. If you do not want to automatically close the error message, set the parameter to false.
+
+```blade
+<script>
+    checkPinShowError = (code) => {
+        ...
+        // the error message will not hide after 10 seconds
+        showPinError('pcode', false);
+        ...
+    }
+</script>
+```
+
+## Show the Spinner
+
+The verification code component comes with a hidden spinner that can be made visible by invoking the `showSpinner(name)` Javascript helper function. It accepts the name provided to the code component as a parameter. The verification code spinner can be useful if your verification is done via an ajax call to an API that may take a second or two. Showing the spinner will let the user know you are performing an action.
+
+```blade
+<x-bladewind::code name="spin_me" onverify="validatePin"  />
+```
+
+```blade
+<script>
+    validatePin = (code, name) => {
+        showSpinner(name);
+        ajaxCall('/verify/pin', `code=${code}`, ...
+    }
+</script>
+```
+
+Since Bladewind does not know how long your Ajax call might take or when your process is complete, it cannot automatically hide the spinner for you. You can do that by calling `hideSpinner(name)`, where `name` is the name of your verification code field.
+
+```blade
+<script>
+    ...
+    hideSpinner('spin_me');
+    ...
+</script>
+```
+
+## Show Success Icon
+
+The verification code component also comes with a hidden checkmark to show when a pin is valid. This can be invoked using the `showPinSuccess(name)` Javascript helper function. It accepts the name provided to the code component as a parameter. In the example below, the spinner shows after the code is entered and disappears to give way to the checkmark after 5 seconds.
+
+```blade
+<x-bladewind::code name="spin_me_yes" onverify="spinAndSucceed"  />
+```
+
+```blade
+<script>
+    spinAndSucceed = (code, name) => {
+        showSpinner(name);
+        setTimeout( () => { showPinSuccess(name); }, 5000);
+    }
+</script>
+```
+
+## Countdown To Resend Code
+
+This can be useful for two scenarios. The user never received the code you sent so they will need to request another. The user received a code that somehow does not seem to work and will need to request for a new one. Specifying a value for the `timer` attribute automatically shows a countdown timer. The attributes accepts number of seconds to countdown to.
+
+Bladewind expects you to have an HTML element on your page with `class="bw-code-timer-done"`. Ideally this should be hidden. The innerHTML (content) of that element is what will be displayed when the timer is done. This approach provides you the flexibility of handling your code resend anyway you want.
+
+```blade
+<x-bladewind::code name="time_me" timer="30"  />
+```
+
+```blade
+<!-- the DIV that contains the content to display when timer is done -->
+
+<div class="bw-code-timer-done hidden">
+    <x-bladewind.button
+        name="send-code"
+        size="tiny"
+        type="secondary"
+        has_spinner="true"
+        onclick="sendNewCode()">
+        send me another code
+    </x-bladewind.button>
+</div>
+```
+
+Once the countdown is done, the content of your `bw-code-timer-done` DIV is copied into a DIV that can be accessed using the class `.bw-[name-of-code-field]-pin-timer .done`.
+
+```blade
+<script>
+    sendNewCode = () => {
+       showButtonSpinner('.bw-time_me-timer .done .send-code');
+       setTimeout( () => {
+           showNotification('Code Sent','Please check your email or SMS for a new verification code');
+            hideButtonSpinner('.bw-time_me-pin-timer .done .send-code');
+            hide('.bw-time_me-pin-timer .done .send-code')
+            setFocus('time_me');
+            clearTimeout();
+       }, 5000);
+    }
+</script>
+```
+
+### Manually Trigger the Timer
+
+There are cases where you may want to manually trigger the timer. For example, you first want the user to have at least entered the code wrongly once or twice before you trigger a countdown. You can do this by calling the `showTimer(name, duration)` helper function.
+
+```blade
+<x-bladewind::code name="trigger_me" onverify="triggerTimerManually"  />
+```
+
+```blade
+let attempts = 0;
+triggerTimerManually = (code, name) => {
+    if(parseInt(code) !== 2024) {
+        attempts++
+        showPinError(name);
+        clearPin(name);
+    }
+    if(attempts >= 2) showTimer(name, 15);
+}
+```
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| name | pin-code-{uniqid()} | Unique name for the component. The code entered by the end user will be available in an input field with the specified name. |
+| total_digits | 4 | Determines number of input boxes to be created for entry of the verification code. Any realistic number. |
+| size | small | Displays the input boxes at either small or big sizes. `small` \| `big` |
+| onverify | _(blank)_ | Function to call after user has finished entering the codes. This should just be the function name without parentheses and parameters. |
+| error_message | Verification code is invalid | Error message to display when the verification code entered is invalid. |
+| mask | false | Should the text being entered be hidden like a password field. `true` \| `false` |
+| timer | null | Determines if the component should automatically display a timer for user to resend verification code. Accepts any positive integer counted in seconds. |
+| nonce | null | Used when implementing context security policies and require to pass a nonce to inline scripts. |
+
+## Full Example
+
+```blade
+<x-bladewind::code
+    name="pin-code"
+    total_digits="5"
+    onverify="verifyPin"
+    has_spinner="false"
+    mask="false"
+    timer="15"
+    error_message="please enter the correct code"  />
+```

--- a/resources/views/components/topright.blade.php
+++ b/resources/views/components/topright.blade.php
@@ -9,6 +9,7 @@
             </span>
         </x-slot:trigger>
         <x-bladewind::dropmenu.item>{{\Composer\InstalledVersions::getPrettyVersion('mkocansey/bladewind')}}</x-bladewind::dropmenu.item>
+        <x-bladewind::dropmenu.item onclick="location.href='https://v3.bladewindui.com/install'">3.x</x-bladewind::dropmenu.item>
         <x-bladewind::dropmenu.item onclick="location.href='https://v2.bladewindui.com/install'">2.x</x-bladewind::dropmenu.item>
     </x-bladewind::dropmenu>
 </div>

--- a/resources/views/docs/components-list.blade.php
+++ b/resources/views/docs/components-list.blade.php
@@ -8,14 +8,14 @@
 <div class="{{ $css }} component-button"><div class="dot"></div><a href="/component/button">Button</a></div>
 <div class="{{ $css }} component-card"><div class="dot"></div><a href="/component/card">Card</a></div>
 <div class="{{ $css }} component-centered-content"><div class="dot"></div><a href="/component/centered-content">Centered Content</a></div>
-<div class="{{ $css }} component-chart"><div class="dot"></div><a href="/component/chart">Chart <x-bladewind::icon name="bolt" type="solid" class="text-pink-600 !size-3 ml-1" /></a></div>
+<div class="{{ $css }} component-chart"><div class="dot"></div><a href="/component/chart">Chart</a></div>
 <div class="{{ $css }} component-checkbox"><div class="dot"></div><a href="/component/checkbox">Checkbox</a></div>
-<div class="{{ $css }} component-checkcard"><div class="dot"></div><a href="/component/checkcard">CheckCard  <x-bladewind::icon name="bolt" type="solid" class="text-pink-600 !size-3 ml-1" /></a></div>
+<div class="{{ $css }} component-checkcard"><div class="dot"></div><a href="/component/checkcard">CheckCard </a></div>
 <div class="{{ $css }} component-colorpicker"><div class="dot"></div><a href="/component/colorpicker">Colorpicker</a></div>
 <div class="{{ $css }} component-datepicker"><div class="dot"></div><a href="/component/datepicker">Datepicker</a></div>
 <div class="{{ $css }} component-dropmenu"><div class="dot"></div><a href="/component/dropmenu">Dropmenu</a></div>
 <div class="{{ $css }} component-empty-state"><div class="dot"></div><a href="/component/empty-state">Empty State</a></div>
-<div class="{{ $css }} component-filepicker"><div class="dot"></div><a href="/component/filepicker">Filepicker <x-bladewind::icon name="bolt" type="solid" class="text-pink-600 !size-3 ml-1" /></a></div>
+<div class="{{ $css }} component-filepicker"><div class="dot"></div><a href="/component/filepicker">Filepicker</a></div>
 <div class="{{ $css }} component-hlg"><div class="dot"></div><a href="/component/horizontal-line-graph">Horizontal Line Graph</a></div>
 <div class="{{ $css }} component-icon"><div class="dot"></div><a href="/component/icon">Icon</a></div>
 <div class="{{ $css }} component-input"><div class="dot"></div><a href="/component/input">Input</a></div>
@@ -23,23 +23,24 @@
 <div class="{{ $css }} component-modal"><div class="dot"></div><a href="/component/modal">Modal</a></div>
 <div class="{{ $css }} component-notification"><div class="dot"></div><a href="/component/notification">Notification</a></div>
 <div class="{{ $css }} component-number"><div class="dot"></div><a href="/component/number">Number</a></div>
+{{--<div class="{{ $css }} component-popover hidden"><div class="dot"></div><a href="/component/popover">Popover</a></div>--}}
 <div class="{{ $css }} component-process-indicator"><div class="dot"></div><a href="/component/process-indicator">Process Indicator</a></div>
 <div class="{{ $css }} component-progress-bar"><div class="dot"></div><a href="/component/progress-bar">Progress Bar</a></div>
 <div class="{{ $css }} component-progress-circle"><div class="dot"></div><a href="/component/progress-circle">Progress Circle</a></div>
 <div class="{{ $css }} component-radio-button"><div class="dot"></div><a href="/component/radio-button">Radio Button</a></div>
 <div class="{{ $css }} component-rating"><div class="dot"></div><a href="/component/rating">Rating</a></div>
 <div class="{{ $css }} component-select"><div class="dot"></div><a href="/component/select">Select</a></div>
-<div class="{{ $css }} component-shimmer"><div class="dot"></div><a href="/component/shimmer">Shimmer <x-bladewind::icon name="bolt" type="solid" class="text-pink-600 !size-3 ml-1" /></a></div>
+<div class="{{ $css }} component-shimmer"><div class="dot"></div><a href="/component/shimmer">Shimmer</a></div>
 <div class="{{ $css }} component-slider"><div class="dot"></div><a href="/component/slider">Slider</a></div>
 <div class="{{ $css }} component-spinner"><div class="dot"></div><a href="/component/spinner">Spinner</a></div>
 <div class="{{ $css }} component-statistic"><div class="dot"></div><a href="/component/statistic">Statistic</a></div>
 <div class="{{ $css }} component-tab"><div class="dot"></div><a href="/component/tab">Tab</a></div>
-<div class="{{ $css }} component-table"><div class="dot"></div><a href="/component/table">Table <x-bladewind::icon name="bolt" type="solid" class="text-pink-600 !size-3" /></a></div>
+<div class="{{ $css }} component-table"><div class="dot"></div><a href="/component/table">Table</a></div>
 <div class="{{ $css }} component-tag"><div class="dot"></div><a href="/component/tag">Tag</a></div>
 <div class="{{ $css }} component-textarea"><div class="dot"></div><a href="/component/textarea">Textarea</a></div>
 <div class="{{ $css }} component-theme-switcher"><div class="dot"></div><a href="/component/theme-switcher">Theme Switcher</a></div>
 <div class="{{ $css }} component-timeline"><div class="dot"></div><a href="/component/timeline">Timeline</a></div>
-<div class="{{ $css }} component-timepicker"><div class="dot"></div><a href="/component/timepicker">Timepicker <x-bladewind::icon name="bolt" type="solid" class="text-pink-600 !size-3 ml-1" /></a></div>
+<div class="{{ $css }} component-timepicker"><div class="dot"></div><a href="/component/timepicker">Timepicker</a></div>
 {{--<div class="{{ $css }} component-tooltip hidden"><div class="dot"></div><a href="/component/tooltip">Tooltip</a></div>--}}
 <div class="{{ $css }} component-toggle"><div class="dot"></div><a href="/component/toggle">Toggle</a></div>
 <div class="{{ $css }} component-code"><div class="dot"></div><a href="/component/verification-code">Verification Code</a></div>

--- a/resources/views/docs/customize.blade.php
+++ b/resources/views/docs/customize.blade.php
@@ -2,10 +2,11 @@
     <x-slot:title>Customizing BladewindUI</x-slot:title>
     <x-slot:page_title>Customizing BladewindUI</x-slot:page_title>
     <p>
-        BladewindUI has been designed to not interfere with the existing components in your project.
-        Probably you just want to take this for a spin before deciding if BladewindUI components will be the only components you use in your project.
-        Once installed, all BladewindUI components are invoked by default from your project's <code class="inline">vendor > mkocansey > bladewind</code> directory.
-        Per Laravel convention, this results in you having to type the <code class="inline text-red-400">&lt;x-bladewind</code> prefix everytime you want to use a BladewindUI component.
+        BladewindUI is designed to work seamlessly with your existing project components. Once installed, all BladewindUI
+        components are served directly from your project’s vendor directory.  Each component resides in its own Composer
+        package, such as <code class="inline">vendor/mkocansey/bladewind-button</code> or
+        <code class="inline">vendor/mkocansey/bladewind-table</code>. However, they all share
+        the same <code class="inline text-red-400">bladewind::</code> view namespace.  This Laravel convention means you’ll need to type the <code class="inline text-red-400">&lt;x-bladewind</code> prefix every time you use a BladewindUI component.
     </p>
     <pre class="language-markup">
         <code>
@@ -18,12 +19,27 @@
     </p>
     <pre class="language-markup">
         <code>
-            &lt;<b>x-bladewind</b>.button&gt;Save User&lt;/x-bladewind.button&gt;
+            &lt;x-bladewind.button&gt;Save User&lt;/x-bladewind.button&gt;
         </code>
     </pre>
     <h2 id="noprefix">Getting rid of the <b class="font-bold">bladewind</b> prefix </h2>
+    <p>It is possible to get rid of the bladewind prefix entirely. </p>
+    <pre class="language-markup">
+        <code>
+            &lt;x-bladewind.button&gt;Save User&lt;/x-bladewind.button&gt;
+
+            // or
+
+            &lt;x-bladewind::button&gt;Save User&lt;/x-bladewind::button&gt;
+        </code>
+    </pre>
+    becomes
+    <pre class="language-markup">
+        <code>
+            &lt;x.button&gt;Save User&lt;/x-button&gt;
+        </code>
+    </pre>
     <p>
-        It is possible to get rid of the bladewind prefix entirely. <code class="inline text-red-400">&lt;x-bladewind.button&gt;Save User&lt;/x-bladewind.button&gt;</code> becomes <code class="inline text-red-400">&lt;x-button&gt;Save User&lt;/x-button&gt;</code>.
         To achieve this, you should have already <a href="/#publishing">published the Bladewind components</a>. Next you will move all the blade files in <code class="inline">resources > views > components > bladewind</code> into <code class="inline">resources > views > components</code>.
         You can then delete the <span>bladewind</span> folder from your <code class="inline">resources > views > components</code> folder since it should technically be empty at this point.
     </p>
@@ -53,9 +69,9 @@
      </p>
     <h2 id="datepicker-translations">Changing Datepicker Translations</h2>
     <p>
-        The <a href="/component/datepicker">Datepicker component</a> is wired to speak a couple of languages. The language files are served from BladewindUI's vendor directory,
+        The <a href="/component/datepicker">Datepicker component</a> is wired to speak a couple of languages. The language files are part of the <code class="inline">bladewind-core</code> package and are served from
         <code class="inline">
-            vendor > mkocansey > bladewind > lang
+            vendor > mkocansey > bladewind-core > lang
         </code>. Currently the available languages contributed by the community are English, French, Italian, Arabic, German, Chinese, Spanish and Indonesian. You can add more languages as you see fit or even modify the existing translations. If you want to do this for just your project you will first need to publish the language files by running the command below from the root of your project.
         You can <a href="/contribute">contribute</a> a new language translation.
     </p>
@@ -72,22 +88,29 @@
         Now what if you also need all your buttons to be <b>small</b> and to have <b>no focus rings</b>, your code every time will be
     </p>
     <pre class="lang-markup">
-        <code> &lt;x-bladewind-button show_focus_ring="false" size="small" uppercasing="false"&gt
+        <code> &lt;x-bladewind::button show_focus_ring="false" size="small" uppercasing="false"&gt
             Save
-        &lt;/x-bladewind-button&gt;</code>
+        &lt;/x-bladewind::button&gt;</code>
     </pre>
     <p>
-        Mehn!! This is crazily tedious. Won't it be great to just type the code below to get a button looking the way you'd want for your project?
+        This is tedious. Won't it be great to just type the code below to get a button looking the way you'd want for your project?
     </p>
     <pre class="lang-markup">
-        <code> &lt;x-bladewind-button&gtSave&lt;/x-bladewind-button&gt;</code>
+        <code> &lt;x-bladewind::button&gtSave&lt;/x-bladewind::button&gt;</code>
     </pre>
     <p>
-        To achieve this, simply publish the BladewindUI config file by running the code below from the root of your proejct.
+        To achieve this, create a <code class="inline">config/bladewind.php</code> file in the root of your project. If you installed the full
+        <code class="inline">mkocansey/bladewind</code> package you can have Laravel generate this file for you:
     </p>
-    <pre class="lang-bash"><code>php artisan vendor:publish --tag=bladewind-config --force</code></pre><br />
+    <pre class="lang-bash"><code>php artisan vendor:publish --tag=bladewind-config --force</code></pre>
     <p>
-        You will now have a <code class="inline">your project root > config > bladewind.php</code> file with some boilerplate code you can edit or add to.
+        If you installed individual component packages (e.g. <code class="inline">mkocansey/bladewind-button</code>) the <code class="inline">bladewind-config</code>
+        publish tag is not available. Simply create the file manually instead:
+    </p>
+    <pre class="lang-bash"><code>touch config/bladewind.php</code></pre>
+    <p>
+        Either way, you will end up with a <code class="inline">config/bladewind.php</code> file you can edit.
+        You only need to define the components and attributes you want to change. You do not have to copy the full default configuration.
         Every BladewindUI component is defined as an array key with some default values. Whatever attributes you wish to define as a default should be
         defined within its corresponding tag's array key. The code below is for the above example where we want all our buttons to be small, have no
         focus rings and not be uppercase.

--- a/resources/views/docs/index.blade.php
+++ b/resources/views/docs/index.blade.php
@@ -22,7 +22,7 @@
         @include('docs/nav')
     </nav>
 
-    <div class="bg-gradient-to-tr from-purple-600 via-blue-800 to-pink-500 sm:px-10 px-5 pb-10 shadow-sm dark:from-dark-700 dark:via-black dark:to-violet-950">
+    <div class="bg-gradient-to-tr from-purple-600 via-blue-800 to-pink-700 sm:px-10 px-5 pb-10 shadow-sm dark:from-dark-700 dark:via-black dark:to-violet-950">
         <div class="sm:max-w-7xl mx-auto flex justify-between items-center py-7">
             <div>
                 <img src="/assets/images/bw-logo-white.png" alt="logo" class="h-7 mx-auto opacity-80" />

--- a/resources/views/docs/index.blade.php
+++ b/resources/views/docs/index.blade.php
@@ -5,10 +5,9 @@
 <x-bladewind::notification />
 <body class="text-gray-500/80 bg-slate-100 dark:bg-gradient-to-b from-slate-900 to-slate-800 dark:text-slate-400">
     <div class="md:hidden block absolute right-6 top-6" onclick="animateCss('.navigation','slideInRight');">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-        </a>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
     </div>
 
     <nav class="w-[280px] z-50 py-6 bg-white/95 border-l border-gray-200 fixed right-0 top-0 h-screen shadow-2xl
@@ -23,23 +22,25 @@
         @include('docs/nav')
     </nav>
 
-    <div class="bg-gradient-to-tr from-indigo-900 via-black to-violet-500 sm:px-10 px-5 pb-10 shadow-sm dark:from-dark-700 dark:via-black dark:to-violet-950">
+    <div class="bg-gradient-to-tr from-purple-600 via-blue-800 to-pink-500 sm:px-10 px-5 pb-10 shadow-sm dark:from-dark-700 dark:via-black dark:to-violet-950">
         <div class="sm:max-w-7xl mx-auto flex justify-between items-center py-7">
             <div>
                 <img src="/assets/images/bw-logo-white.png" alt="logo" class="h-7 mx-auto opacity-80" />
             </div>
             <div class="hidden md:flex justify-end items-center space-x-5">
-                <a href="/install" class="text-white/70 hover:text-white/80 pr-6 border-r border-dashed border-r-white/20 tracking-wider">Docs</a>
                 <x-topright />
+                <a href="/install">
+                    <x-bladewind::button radius="full"  size="small" color="black">Get Started</x-bladewind::button>
+                </a>
             </div>
         </div>
         <div class="sm:text-6xl tracking-wide font-bold text-3xl sm:max-w-5xl mx-auto text-fuchsia-100 dark:text-dark-200 text-center px-6 pt-10 md:px-3 md:pt-20 font-bladewind">
             Beautifully crafted UI components for your Laravel applications.
         </div>
-        <div class="sm:text-2xl text-sm font-light tracking-wide sm:max-w-2xl mx-auto text-center text-slate-100 dark:text-dark-400 sm:py-8 px-5 pt-3 pb-6">
-            Just <code class="font-bladewind2 md:text-xl text-sm">`composer require mkocansey/bladewind`</code> and start combining our elements to build something amazing.
+        <div class="sm:text-2xl text-sm font-light tracking-wide sm:max-w-3xl mx-auto text-center text-slate-100 dark:text-dark-400 sm:py-8 px-5 pt-3 pb-6">
+            With over 40 components at your disposal, you can build experiences like what is shown in the demo below in no time. Even works seamlessly with most of Laravel's starter kits.
         </div>
-        <div class="text-center sm:py-6 px-6">
+        <div class="text-center sm:py-6 px-6 hidden">
             <x-bladewind::button radius="full" color="orange" tag="a" href="/install" size="big" class="font-bladewind w-full md:w-fit">Get Started Now</x-bladewind::button>
         </div>
 
@@ -85,9 +86,9 @@
         </div>
     </div>
 
-    <div class="bg-slate-200 sm:px-10 sm:py-20 py-10 px-4 shadow-sm dark:bg-dark-700">
-        <div class="text-3xl sm:text-6xl sm:max-w-4xl mx-auto text-slate-700 dark:text-dark-300 text-center px-10">
-            Usually just one line but packed with cool stuff
+    <div class="bg-purple-200 sm:px-10 sm:py-20 py-10 px-4 shadow-sm dark:bg-dark-700 border-t-8 border-purple-300">
+        <div class="text-3xl font-bladewind font-semibold tracking-tight sm:text-6xl sm:max-w-4xl mx-auto text-slate-700 dark:text-dark-300 text-center px-5">
+            One line of code unpacks a ton of useful features.
         </div>
         <div class="text-sm sm:text-2xl tracking-wide font-light sm:max-w-xl mx-auto sm:pt-6 pt-2 text-center text-slate-500 dark:text-dark-400 px-4 sm:px-0">
             This library follows the Laravel way of simplicity and development fun.
@@ -103,25 +104,34 @@
             </div>
         </div>
     </div>
-<div class="bg-white sm:px-10 sm:py-16 px-6 py-8 shadow-sm dark:bg-dark-800">
-    <div class="text-3xl sm:text-6xl font-light sm:max-w-4xl mx-auto text-slate-700 dark:text-dark-200 text-center px-10 font-bladewind">
-        There's no Pro or Pro Max. Just <span class="underline">free</span> everything.
+<div class="bg-blue-200 sm:px-10 sm:py-16 px-6 py-8 shadow-sm dark:bg-dark-800 border-t-8 border-blue-300">
+    <div class="text-3xl sm:text-6xl font-semibold sm:max-w-4xl mx-auto tracking-tight text-slate-700 dark:text-dark-200 text-center px-5 font-bladewind">
+        Only install the components you need. Not everything.
     </div>
-    <div class="text-sm sm:text-xl font-light sm:max-w-xl mx-auto sm:py-8 pt-4 pb-6 text-center text-slate-500 dark:text-dark-400 px-4 tracking-wide font-bladewind">
-        All current and future UI components plus their frequent updates remain free forever. <a href="/contribute" class="text-indigo-500 hover:text-indigo-700">Contributions</a> are welcome.
+    <div class="text-sm sm:text-xl font-light sm:max-w-2xl mx-auto sm:py-8 pt-4 pb-6 text-center text-slate-500 dark:text-dark-400 px-4 tracking-wide font-bladewind">
+        All components are standalone composer packages and can be installed separately. Dependencies are automatically carried along.
+        <pre class="language-php !text-center"><code>composer require mkocansey/bladewind-table</code></pre>
     </div>
 
     <div class="sm:max-w-7xl home-nav mx-auto pt-4 pb-6 sm:grid-cols-5 grid grid-cols-2 sm:gap-6 gap-3">
         @include('docs.components-list', [ 'class' => 'home'])
     </div>
 </div>
+<div class="bg-yellow-200 sm:px-10 sm:py-16 px-6 py-8 shadow-sm dark:bg-dark-800 border-t-8 border-yellow-300">
+    <div class="text-3xl sm:text-6xl font-semibold sm:max-w-4xl mx-auto text-slate-700 dark:text-dark-200 text-center px-5 font-bladewind">
+        Now with an MCP Server to support your favourite AI tools.
+    </div>
+    <div class="text-sm sm:text-xl font-light sm:max-w-2xl mx-auto sm:py-8 pt-4 pb-6 text-center text-slate-500 dark:text-dark-400 px-4 tracking-wide font-bladewind">
+        This means tools like Claude Desktop, Cursor, and VS Code Copilot can answer questions about BladewindUI components, generate correct usage examples, and look up attribute names and defaults
+    </div>
+</div>
 
 <div class="bg-slate-900 sm:px-10 sm:py-20 py-10 px-4">
-    <div class="text-3xl sm:text-6xl sm:max-w-4xl mx-auto text-slate-200 text-center px-10 font-bladewind">
+    <div class="text-3xl font-semibold sm:text-6xl sm:max-w-4xl mx-auto text-slate-200 text-center px-10 font-bladewind">
         BladewindUI components shine even in dark mode.
     </div>
     <div class="text-sm sm:text-2xl font-light sm:max-w-xl mx-auto pt-4 text-center text-slate-300 px-4 sm:px-0 font-bladewind tracking-wide">
-        <a href="/customize/darkmode" class="text-yellow-500 hover:text-yellow-700">Customizing</a> dark mode in BladewinUI is as easy as setting your preferred dark colour and voila!.
+        <a href="/customize/darkmode" class="text-yellow-500 hover:text-yellow-700">Customizing</a> dark mode in BladewinUI is as easy as setting your preferred dark colour and voila!
     </div>
 
     <div class="sm:max-w-7xl home-nav mx-auto pt-16">

--- a/resources/views/docs/install.blade.php
+++ b/resources/views/docs/install.blade.php
@@ -1,74 +1,81 @@
 <x-app>
     <x-slot:title>Getting Started</x-slot:title>
     <x-slot:page_title>Getting Started</x-slot:page_title>
+
     <p>
-        BladewindUI is a collection of super simple but elegant Laravel blade-based UI components using TailwindCSS and vanilla Javascript.
-        While building our Cropchain and Velociti apps at <a href="https://agrocenta.com/platforms.html" target="_blank">AgroCenta</a>,
-        we needed to ensure the UI stayed consistent across all the apps.
-        We couldn't afford to duplicate code since an update to a component in one app meant updating that component across all apps.
-        That's how BladewindUI was born. A set of UI elements that enabled us to achieve a consistent UI.
+        BladewindUI is a collection of UI components built with TailwindCSS, Laravel Blade templates, and vanilla JavaScript.
+        Every component is simple to use and ships with sensible defaults you can override per-project.
     </p>
-    <h2 id="required">Requirements </h2>
-    <p>Bladewind components are purely Laravel blade components sprinkled with some <a href="https://tailwindcss.com">TailwindCSS</a> sauce. This means you absolutely need to be using BladewindUI in a Laravel project. The package has the following dependencies:</p>
-    <p>- PHP >= 8.0 <br />- Laravel >= 9.x</p>
 
-    <h2 id="install">Install</h2>
-    <p>At the root of your Laravel project, type the following composer command in your terminal to pull in the package.</p>
+    <h3 id="requirements">Requirements</h3 id="requirements">
+    <div class="pl-5">
+    <li class="pb-2">PHP &gt;= 8.0</li>
+    <li>Laravel &gt;= 9.x</li>
+    </div>
 
+    <h2 id="install">Installation Options</h2>
+    <p>
+        There are three ways to install BladewindUI depending on how much of the library you need.
+    </p>
+
+    <h3 id="install-all">Install everything </h3>
+    <p>
+        Pull in every component at once. This is the easiest way to get started and is ideal for new projects or if you want to explore the full library.
+    </p>
     <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind</code></pre>
+
+    <h3 id="install-group">Install a component group</h3>
     <p>
-        Next you need to <b>publish the package's public assets</b> by running the command below, still at the root of your Laravel project. This will create a <code class="inline">vendor/bladewind</code> directory in your <code class="inline">public</code> directory.
+        Components are organised into three groups. Install a group when you only need a logical subset of BladewindUI.
+        See the <a href="#groups">component groups</a> section below for exactly which components each group contains.
     </p>
-    <pre class="lang-js">
-        <code>
-            php artisan vendor:publish --tag=bladewind-public --force
-        </code>
-    </pre>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-forms</code></pre>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-content</code></pre>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-navigation</code></pre>
+
+    <h3 id="install-single">Install a single component</h3>
+    <p>
+        The library also allows users to pick only the components they need.
+        This is ideal for existing projects where you want to introduce BladewindUI gradually, or if you only need one or two components.
+    </p>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-table</code></pre>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-accordion</code></pre>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-datepicker</code></pre>
+    <p>
+        All shared dependencies—such as the Icon, Spinner, and core helper utilities—are automatically installed by Composer when you require any BladewindUI package. You do not need to install or configure these dependencies yourself; Composer’s dependency resolution ensures everything required is available and up to date.
+    </p>
+
+    <h2 id="setup">First-time Setup</h2>
+    <p>
+        After installing, publish the compiled CSS, JavaScript, and language files to your project's <code class="inline">public</code> directory.
+    </p>
+    <pre class="lang-bash command-line"><code>php artisan vendor:publish --tag=bladewind-public --force</code></pre>
+{{--    <pre class="lang-bash command-line"><code>php artisan vendor:publish --tag=bladewind-lang --force</code></pre>--}}
+
     <x-bladewind::alert show_close_icon="false" type="warning">
-    IMPORTANT: Always publish assets when you update to a new version of BladewindUI since it is likely some CSS and JS might have been updated. See <a href="#update">Update Notes</a> at the bottom of this page.
+        Always republish assets when you update to a new version of BladewindUI — CSS and JS are updated regularly. See <a href="#update">Updating BladewindUI</a> below.
     </x-bladewind::alert>
 
-<br />
-<br />
-
+    <br />
     <p>
-        Now, include the BladewindUI css and helper javascript files in the <code class="inline">&lt;head&gt;</code> of your pages. This should ideally be done in the layout file your app pages extend from.
-        Your app's css and js files should come after the Bladewind files so your customizations (if any) can take effect.
+        Add the stylesheet to the <code class="inline">&lt;head&gt;</code> of your layout file.
+        Your own CSS should come <em>after</em> the BladewindUI stylesheet so your customisations take effect.
     </p>
-    <pre class="lang-html">
-        <code>
-        &lt;!-----------------------------------------------------------
--- animate.min.css by Daniel Eden (https://animate.style)
--- is required for the animation of notifications and slide out panels
--- you can ignore this step if you already have this file in your project
---------------------------------------------------------------------------->
-
-&lt;link href="&#123;&#123; asset('vendor/bladewind/css/animate.min.css') }}" rel="stylesheet" /&gt;
-        </code>
-    </pre>
-    <pre class="lang-markup">
+    <pre class="language-markup">
         <code>
             &lt;link href="&#123;&#123; asset('vendor/bladewind/css/bladewind-ui.min.css') }}" rel="stylesheet" /&gt;
         </code>
     </pre>
-    <pre class="lang-markup">
-        <code>
-        &lt;script src="&#123;&#123; asset('vendor/bladewind/js/helpers.js') }}">&lt;/script&gt;
-        </code>
-    </pre>
     <p>
-       Finally! If you intend to use the Datepicker component you will need to pull in AlpineJs. Include the code below in your <code class="inline">&lt;head&gt;</code>.
-       You can ignore this step if you are already using AlpineJs in your project.
+        Add the JavaScript anywhere before the closing <code class="inline">&lt;/body&gt;</code> tag.
     </p>
-    <pre class="lang-markup">
+    <pre class="language-markup">
         <code>
-            &lt;script src="//unpkg.com/alpinejs" defer&gt;&lt;/script&gt;
+            &lt;script src="&#123;&#123; asset('vendor/bladewind/js/helpers.js') }}"&gt;&lt;/script&gt;
         </code>
     </pre>
-<br />
-<br />
-    <p>You are now ready to start using any of the BladewindUI components in your application</p>
-
+    <p>You are ready to use any BladewindUI component in your application.</p>
+    <br />
     <p class="text-center">
         <x-bladewind::button>Save User</x-bladewind::button>
     </p>
@@ -77,92 +84,345 @@
             &lt;x-bladewind::button&gt;Save User&lt;/x-bladewind::button&gt;
         </code>
     </pre>
-    <br />
+
     <p>
-        <x-bladewind::code />
+        <x-bladewind::alert show_close_icon="false">
+            You can define your primary, secondary, and dark-mode colours in your project's <code class="inline">tailwind.config.js</code> file.
+            More on <a href="/customize/colours">customising colours</a> here.
+        </x-bladewind::alert>
     </p>
-    <pre class="language-markup">
-        <code>
-            &lt;x-bladewind::code /&gt;
-        </code>
-    </pre>
-<p>
-    <x-bladewind::alert show_close_icon="false">
-You can define your primary, secondary and dark mode colours in your project's <code class="inline">tailwind.config.js</code> file. More on <a href="https://bladewindui.com/customize/colours">customizing colours</a> here.
-    </x-bladewind::alert>
-</p>
 
     <h2 id="publishing">Publishing Components</h2>
     <p>
-        You will notice from the example above we had to use two colons after <code class="inline">x-bladewind</code>. This is because we are serving the views from the package's directory in <code class="inline">vendor/mkocansey</code>.
-        To use the usual dot syntax when calling Laravel components, you will need to publish the BladewindUI views to your views directory using the command below.
+        The double-colon syntax (<code class="inline">x-bladewind::button</code>) serves views directly from the package's
+        <code class="inline">vendor</code> directory. To use the dot syntax instead, publish the component views to your own
+        <code class="inline">resources/views/components/bladewind</code> directory:
     </p>
-{{-- --provider="Mkocansey\Bladewind\BladewindServiceProvider"--}}
     <pre class="lang-bash command-line"><code>php artisan vendor:publish --tag=bladewind-components --force</code></pre>
-    <p>The Bladewind components now exist in your <code class="inline">resources > views > components > bladewind</code> directory. You can now access any of the Bladewind components using the dot syntax.</p>
-
+    <p>You can then call components using the dot syntax:</p>
     <pre class="language-markup">
         <code>
             &lt;x-bladewind.button&gt;Save User&lt;/x-bladewind.button&gt;
         </code>
     </pre>
-    <p class="text-center">
-        <x-bladewind::button>Save User</x-bladewind::button>
+    <x-bladewind::alert show_close_icon="false">
+        If you use the dot syntax, republish the component views after every BladewindUI update.
+    </x-bladewind::alert>
+
+    <h2 id="groups">Component Groups</h2>
+    <p>
+        Components are organised into groups. Each group is a Composer metapackage — it contains no code of its own,
+        just a list of dependencies. Installing a group is identical to installing every component in that group
+        individually. Components can also be installed as standalone packages outside any group.
     </p>
 
-<br />
-    <x-bladewind::alert show_close_icon="false">If you decide to go with the dot syntax, it is important to always publish the BladewindUI components after any update.</x-bladewind::alert>
-<br />
-    <x-bladewind::alert show_close_icon="false" type="warning">If you intend to use bladewindUI in a Laravel 8.x project, please do well to <a href="/laravel8-users">read this</a>.</x-bladewind::alert>
+    <h3 id="standalone">Standalone Packages</h3>
+    <p>
+        These components are not bundled into any group. They are pulled in automatically as dependencies by other
+        components that need them, but you can also require them directly.
+    </p>
+    <x-bladewind::table>
+        <x-slot name="header">
+            <th>Component</th>
+            <th>Composer package</th>
+            <th>Includes</th>
+        </x-slot>
+        <tr>
+            <td>Core</td>
+            <td><code class="inline">mkocansey/bladewind-core</code></td>
+            <td>Shared helpers, CSS variables, helpers.js</td>
+        </tr>
+        <tr>
+            <td><a href="/component/icon">Icon</a></td>
+            <td><code class="inline">mkocansey/bladewind-icon</code></td>
+            <td>SVG icon wrapper (Heroicons)</td>
+        </tr>
+        <tr>
+            <td><a href="/component/button">Button</a></td>
+            <td><code class="inline">mkocansey/bladewind-button</code></td>
+            <td>Button, Circle Button</td>
+        </tr>
+        <tr>
+            <td><a href="/component/modal">Modal</a></td>
+            <td><code class="inline">mkocansey/bladewind-modal</code></td>
+            <td>Modal, Modal Icon</td>
+        </tr>
+        <tr>
+            <td><a href="/component/alert">Alert</a></td>
+            <td><code class="inline">mkocansey/bladewind-alert</code></td>
+            <td>Alert, Notification, Bell</td>
+        </tr>
+        <tr>
+            <td><a href="/component/spinner">Spinner</a></td>
+            <td><code class="inline">mkocansey/bladewind-spinner</code></td>
+            <td>Spinner, Shimmer, Processing, Process Complete</td>
+        </tr>
+        <tr>
+            <td><a href="/component/table">Table</a></td>
+            <td><code class="inline">mkocansey/bladewind-table</code></td>
+            <td>Table, Table Icons</td>
+        </tr>
+    </x-bladewind::table>
+
+    <h3 id="group-forms">Forms Group &mdash; <code class="inline">mkocansey/bladewind-forms</code></h3>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-forms</code></pre>
+    <x-bladewind::table>
+        <x-slot name="header">
+            <th>Component</th>
+            <th>Composer package</th>
+            <th>Includes</th>
+        </x-slot>
+        <tr>
+            <td><a href="/component/input">Input</a></td>
+            <td><code class="inline">mkocansey/bladewind-input</code></td>
+            <td>Input, Error</td>
+        </tr>
+        <tr>
+            <td><a href="/component/textarea">Textarea</a></td>
+            <td><code class="inline">mkocansey/bladewind-textarea</code></td>
+            <td>Textarea</td>
+        </tr>
+        <tr>
+            <td><a href="/component/select">Select</a></td>
+            <td><code class="inline">mkocansey/bladewind-select</code></td>
+            <td>Select, Select Item</td>
+        </tr>
+        <tr>
+            <td><a href="/component/checkbox">Checkbox</a></td>
+            <td><code class="inline">mkocansey/bladewind-checkbox</code></td>
+            <td>Checkbox</td>
+        </tr>
+        <tr>
+            <td><a href="/component/radio-button">Radio Button</a></td>
+            <td><code class="inline">mkocansey/bladewind-radio</code></td>
+            <td>Radio Button</td>
+        </tr>
+        <tr>
+            <td><a href="/component/toggle">Toggle</a></td>
+            <td><code class="inline">mkocansey/bladewind-toggle</code></td>
+            <td>Toggle</td>
+        </tr>
+        <tr>
+            <td><a href="/component/datepicker">Datepicker</a></td>
+            <td><code class="inline">mkocansey/bladewind-datepicker</code></td>
+            <td>Datepicker</td>
+        </tr>
+        <tr>
+            <td><a href="/component/timepicker">Timepicker</a></td>
+            <td><code class="inline">mkocansey/bladewind-timepicker</code></td>
+            <td>Timepicker</td>
+        </tr>
+        <tr>
+            <td><a href="/component/colorpicker">Colorpicker</a></td>
+            <td><code class="inline">mkocansey/bladewind-colorpicker</code></td>
+            <td>Colorpicker</td>
+        </tr>
+        <tr>
+            <td><a href="/component/filepicker">Filepicker</a></td>
+            <td><code class="inline">mkocansey/bladewind-filepicker</code></td>
+            <td>Filepicker (powered by FilePond)</td>
+        </tr>
+        <tr>
+            <td><a href="/component/slider">Slider</a></td>
+            <td><code class="inline">mkocansey/bladewind-slider</code></td>
+            <td>Slider</td>
+        </tr>
+        <tr>
+            <td><a href="/component/checkcard">Checkcards</a></td>
+            <td><code class="inline">mkocansey/bladewind-checkcards</code></td>
+            <td>Checkcards, Checkcard</td>
+        </tr>
+        <tr>
+            <td><a href="/component/number">Number</a></td>
+            <td><code class="inline">mkocansey/bladewind-number</code></td>
+            <td>Number stepper</td>
+        </tr>
+        <tr>
+            <td><a href="/component/verification-code">Verification Code</a></td>
+            <td><code class="inline">mkocansey/bladewind-code</code></td>
+            <td>Verification Code / OTP input</td>
+        </tr>
+    </x-bladewind::table>
+
+    <h3 id="group-content">Content Group &mdash; <code class="inline">mkocansey/bladewind-content</code></h3>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-content</code></pre>
+    <x-bladewind::table>
+        <x-slot name="header">
+            <th>Component</th>
+            <th>Composer package</th>
+            <th>Includes</th>
+        </x-slot>
+        <tr>
+            <td><a href="/component/card">Card</a></td>
+            <td><code class="inline">mkocansey/bladewind-card</code></td>
+            <td>Card, Contact Card</td>
+        </tr>
+        <tr>
+            <td><a href="/component/avatar">Avatar</a></td>
+            <td><code class="inline">mkocansey/bladewind-avatar</code></td>
+            <td>Avatar, Avatars</td>
+        </tr>
+        <tr>
+            <td><a href="/component/accordion">Accordion</a></td>
+            <td><code class="inline">mkocansey/bladewind-accordion</code></td>
+            <td>Accordion, Accordion Item</td>
+        </tr>
+        <tr>
+            <td><a href="/component/tag">Tag</a></td>
+            <td><code class="inline">mkocansey/bladewind-tag</code></td>
+            <td>Tag, Tags</td>
+        </tr>
+        <tr>
+            <td><a href="/component/timeline">Timeline</a></td>
+            <td><code class="inline">mkocansey/bladewind-timeline</code></td>
+            <td>Timeline, Timelines</td>
+        </tr>
+        <tr>
+            <td><a href="/component/statistic">Statistic</a></td>
+            <td><code class="inline">mkocansey/bladewind-statistic</code></td>
+            <td>Statistic</td>
+        </tr>
+        <tr>
+            <td><a href="/component/rating">Rating</a></td>
+            <td><code class="inline">mkocansey/bladewind-rating</code></td>
+            <td>Rating</td>
+        </tr>
+        <tr>
+            <td><a href="/component/horizontal-line-graph">Horizontal Line Graph</a></td>
+            <td><code class="inline">mkocansey/bladewind-horizontal-line-graph</code></td>
+            <td>Horizontal Line Graph</td>
+        </tr>
+        <tr>
+            <td><a href="/component/empty-state">Empty State</a></td>
+            <td><code class="inline">mkocansey/bladewind-empty-state</code></td>
+            <td>Empty State</td>
+        </tr>
+        <tr>
+            <td><a href="/component/centered-content">Centered Content</a></td>
+            <td><code class="inline">mkocansey/bladewind-centered-content</code></td>
+            <td>Centered Content</td>
+        </tr>
+        <tr>
+            <td><a href="/component/chart">Chart</a></td>
+            <td><code class="inline">mkocansey/bladewind-chart</code></td>
+            <td>Chart (line, bar, pie, donut)</td>
+        </tr>
+        <tr>
+            <td><a href="/component/progress-bar">Progress</a></td>
+            <td><code class="inline">mkocansey/bladewind-progress</code></td>
+            <td>Progress Bar, Progress Circle</td>
+        </tr>
+        <tr>
+            <td><a href="/component/list-view">List View</a></td>
+            <td><code class="inline">mkocansey/bladewind-listview</code></td>
+            <td>List View, List View Item</td>
+        </tr>
+    </x-bladewind::table>
+
+    <h3 id="group-navigation">Navigation Group &mdash; <code class="inline">mkocansey/bladewind-navigation</code></h3>
+    <pre class="lang-bash command-line"><code>composer require mkocansey/bladewind-navigation</code></pre>
+    <x-bladewind::table>
+        <x-slot name="header">
+            <th>Component</th>
+            <th>Composer package</th>
+            <th>Includes</th>
+        </x-slot>
+        <tr>
+            <td><a href="/component/tab">Tab</a></td>
+            <td><code class="inline">mkocansey/bladewind-tab</code></td>
+            <td>Tab, Tab Body, Tab Content, Tab Heading</td>
+        </tr>
+        <tr>
+            <td><a href="/component/dropmenu">Dropmenu</a></td>
+            <td><code class="inline">mkocansey/bladewind-dropmenu</code></td>
+            <td>Dropmenu, Dropmenu Item</td>
+        </tr>
+        <tr>
+            <td><a href="/component/theme-switcher">Theme Switcher</a></td>
+            <td><code class="inline">mkocansey/bladewind-theme-switcher</code></td>
+            <td>Theme Switcher (light / dark)</td>
+        </tr>
+    </x-bladewind::table>
+
+    <h2 id="how-groups-work">How Groups Work</h2>
+    <p>
+        The three group packages (<code class="inline">bladewind-forms</code>, <code class="inline">bladewind-content</code>,
+        <code class="inline">bladewind-navigation</code>) contain <strong>no code</strong> — they are pure Composer metapackages
+        whose only job is to pull in the right leaf packages. This means:
+    </p>
+    <ul class="list-disc pl-6 space-y-2 my-4">
+        <li>Installing <code class="inline">mkocansey/bladewind-content</code> is identical to installing every content leaf package individually.</li>
+        <li>Uninstalling a group and requiring just one leaf package (e.g. <code class="inline">mkocansey/bladewind-accordion</code>) is clean and leaves nothing behind.</li>
+        <li>Each leaf package registers its own Laravel service provider, so components are auto-discovered whether you install them individually or as part of a group.</li>
+    </ul>
+
+    <h2 id="customising">Customising Defaults</h2>
+    <p>
+        Every attribute in every component has a project-level default you can override once and have it apply everywhere.
+        Publish the config file (available when using the full <code class="inline">mkocansey/bladewind</code> package):
+    </p>
+    <pre class="lang-bash command-line"><code>php artisan vendor:publish --tag=bladewind-config</code></pre>
+    <p>
+        This creates <code class="inline">config/bladewind.php</code> in your project. Edit any value there and all component
+        instances will follow suit — no need to set the attribute on every tag.
+        See the full <a href="/customize">customisation guide</a> for details.
+    </p>
 
     <h2 id="update">Updating BladewindUI</h2>
     <p>
-        Running <code class="inline">composer update</code> at the root of your project will pull in the latest version of BladewindUI depending on how your dependencies are defined in composer.json.
+        Run <code class="inline">composer update</code> to pull in the latest version.
     </p>
     <pre class="lang-bash command-line"><code>composer update</code></pre>
     <p>
-        It is important to republish the assets after every update to pull in any new css and js changes. Run the command below to publish the BladewindUI assets.
+        Then republish the public assets to pick up any CSS or JavaScript changes:
     </p>
     <pre class="lang-bash command-line"><code>php artisan vendor:publish --tag=bladewind-public --force</code></pre>
-
     <p>
-        If you access the BladewindUI components using the dot syntax, you will need to also republish the components view files by running the command below.
+        If you are using the dot syntax, also republish the component views:
     </p>
     <pre class="lang-bash command-line"><code>php artisan vendor:publish --tag=bladewind-components --force</code></pre>
 
     <p>
-        To automate publishing of the BladewindUI files every time you run  <code class="inline">composer update</code>, you can add the following lines to your <code class="inline">composer.json</code> file under the <code class="inline">scripts</code> key.
+        To automate both publish steps after every <code class="inline">composer update</code>, add the following to your
+        <code class="inline">composer.json</code> under <code class="inline">scripts</code>:
     </p>
-    <pre class="lang-js line-numbers" data-line="5,8">
+    <pre class="lang-js line-numbers" data-line="5,6">
         <code>
-        // composer.json
-        ...
         "scripts": {
-        ...
             "post-update-cmd": [
                 "@php artisan vendor:publish --tag=laravel-assets --ansi",
                 "@php artisan vendor:publish --tag=bladewind-public --force",
-                // add this next line if you also want to automatically publish
-                // the components to your resources > views > components directory
+                // add this line only if you also publish component views
                 "@php artisan vendor:publish --tag=bladewind-components --force"
-            ],
-            ...
+            ]
+        }
         </code>
     </pre>
     <x-bladewind::alert show_close_icon="false" type="warning">
-    IMPORTANT: Any changes you may have made to the BladewindUI component view files will be lost anytime you publish the components or enable automatic publishing of the components.
+        Any changes you have made to published BladewindUI component view files will be overwritten when you republish the components.
     </x-bladewind::alert>
+
     <p>&nbsp;</p>
     <p>&nbsp;</p>
-    <p>&nbsp;</p>
-    <p>&nbsp;</p>
+
     <x-slot:side_nav>
-        <div class="flex items-center"><div class="dot"></div><a href="#required">Requirements</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#requirements">Requirements</a></div>
         <div class="flex items-center"><div class="dot"></div><a href="#install">Install</a></div>
+        <div class="flex items-center pl-5"><div class="dot"></div><a href="#install-all">Install everything</a></div>
+        <div class="flex items-center pl-5"><div class="dot"></div><a href="#install-group">Install a group</a></div>
+        <div class="flex items-center pl-5"><div class="dot"></div><a href="#install-single">Install a single component</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#setup">First-time setup</a></div>
         <div class="flex items-center"><div class="dot"></div><a href="#publishing">Publishing components</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#groups">Component groups</a></div>
+        <div class="flex items-center pl-5"><div class="dot"></div><a href="#standalone">Standalone</a></div>
+        <div class="flex items-center pl-5"><div class="dot"></div><a href="#group-forms">Forms</a></div>
+        <div class="flex items-center pl-5"><div class="dot"></div><a href="#group-content">Content</a></div>
+        <div class="flex items-center pl-5"><div class="dot"></div><a href="#group-navigation">Navigation</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#how-groups-work">How groups work</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#customising">Customising defaults</a></div>
         <div class="flex items-center"><div class="dot"></div><a href="#update">Updating BladewindUI</a></div>
-        <div class="flex items-center"><div class="dot"></div><a href="/customize/colours">Define your theme colours</a></div>
     </x-slot:side_nav>
+
     <x-slot name="scripts">
         <script>
             selectNavigationItem('.installation');

--- a/resources/views/docs/mcp.blade.php
+++ b/resources/views/docs/mcp.blade.php
@@ -33,6 +33,11 @@
 
     <h2 id="claude-desktop">Claude Desktop</h2>
     <p>
+        Claude Desktop communicates with MCP servers over stdio, so connecting to a remote HTTP server requires
+        a small proxy called <code class="inline">mcp-remote</code>. You will need
+        <a href="https://nodejs.org" target="_blank">Node.js</a> installed on your machine.
+    </p>
+    <p>
         Open your Claude Desktop configuration file:
     </p>
     <ul class="list-disc pl-6 space-y-1">
@@ -40,22 +45,26 @@
         <li>Windows: <code class="inline">%APPDATA%\Claude\claude_desktop_config.json</code></li>
     </ul>
     <p>
-        Add the following entry inside <code class="inline">mcpServers</code>:
+        Add the following entry inside <code class="inline">mcpServers</code>, replacing <code class="inline">/usr/local/bin/npx</code>
+        with the full path to <code class="inline">npx</code> on your machine
+        (run <code class="inline">which npx</code> in your terminal to find it):
     </p>
     <pre class="language-js line-numbers">
 <code>
 {
   "mcpServers": {
     "bladewindui": {
-      "type": "http",
-      "url": "https://bladewindui.com/mcp/server"
+      "command": "/usr/local/bin/npx",
+      // "command": "npx", use this on Windows or if npx is in your PATH
+      "args": ["-y", "mcp-remote", "https://bladewindui.com/mcp/server"]
     }
   }
 }
 </code>
     </pre>
     <p>
-        Save the file and restart Claude Desktop. You will see <strong>bladewindui</strong> listed as a connected MCP server.
+        Save the file and restart Claude Desktop fully (quit and reopen — do not just close the window).
+        Once connected, a hammer icon will appear at the bottom of a new chat showing the available tools.
         You can then ask questions like <em>"Show me all the attributes for the BladewindUI table component"</em>
         or <em>"How do I use the filepicker with automatic uploads?"</em> and Claude will read the answer directly from the docs.
     </p>

--- a/resources/views/docs/mcp.blade.php
+++ b/resources/views/docs/mcp.blade.php
@@ -1,0 +1,157 @@
+<x-app>
+    <x-slot:title>MCP Server</x-slot:title>
+    <x-slot:page_title>MCP Server</x-slot:page_title>
+
+    <p>
+        The <a href="https://modelcontextprotocol.io" target="_blank">Model Context Protocol</a> (MCP) is an open standard that lets AI assistants
+        read structured context from external sources. BladewindUI runs a remote MCP server at
+        <code class="inline">https://bladewindui.com/mcp/server</code> that exposes the full component documentation to
+        any MCP-compatible AI tool.
+    </p>
+    <p>
+        This means tools like Claude Desktop, Cursor, and VS Code Copilot can answer questions about BladewindUI components,
+        generate correct usage examples, and look up attribute names and defaults — with no copy-pasting, no repo cloning,
+        and no local setup required.
+    </p>
+
+    <h2 id="what-is-available">What Is Available</h2>
+    <p>
+        The MCP server exposes two types of context:
+    </p>
+    <ul class="list-disc pl-6 space-y-2">
+        <li>
+            <strong>Resources</strong> — one resource per component (e.g. <code class="inline">bladewindui://docs/button</code>),
+            plus an index at <code class="inline">bladewindui://docs/index</code>.
+            Each resource is the full Markdown documentation for that component including usage examples and attribute tables.
+        </li>
+        <li>
+            <strong>Tools</strong> — three callable tools the AI can invoke:
+            <code class="inline">list_components</code>, <code class="inline">get_component_docs</code>,
+            and <code class="inline">search_components</code>.
+        </li>
+    </ul>
+
+    <h2 id="claude-desktop">Claude Desktop</h2>
+    <p>
+        Open your Claude Desktop configuration file:
+    </p>
+    <ul class="list-disc pl-6 space-y-1">
+        <li>macOS: <code class="inline">~/Library/Application Support/Claude/claude_desktop_config.json</code></li>
+        <li>Windows: <code class="inline">%APPDATA%\Claude\claude_desktop_config.json</code></li>
+    </ul>
+    <p>
+        Add the following entry inside <code class="inline">mcpServers</code>:
+    </p>
+    <pre class="language-js line-numbers">
+<code>
+{
+  "mcpServers": {
+    "bladewindui": {
+      "type": "http",
+      "url": "https://bladewindui.com/mcp/server"
+    }
+  }
+}
+</code>
+    </pre>
+    <p>
+        Save the file and restart Claude Desktop. You will see <strong>bladewindui</strong> listed as a connected MCP server.
+        You can then ask questions like <em>"Show me all the attributes for the BladewindUI table component"</em>
+        or <em>"How do I use the filepicker with automatic uploads?"</em> and Claude will read the answer directly from the docs.
+    </p>
+
+    <h2 id="cursor">Cursor</h2>
+    <p>
+        Open <strong>Cursor Settings → MCP</strong> and click <strong>Add new global MCP server</strong>,
+        or edit <code class="inline">~/.cursor/mcp.json</code> directly:
+    </p>
+    <pre class="language-js line-numbers">
+<code>
+{
+  "mcpServers": {
+    "bladewindui": {
+      "type": "http",
+      "url": "https://bladewindui.com/mcp/server"
+    }
+  }
+}
+</code>
+    </pre>
+    <p>
+        For a project-scoped setup — useful when you want every developer on a team to get BladewindUI context automatically —
+        create <code class="inline">.cursor/mcp.json</code> at the root of your Laravel project and commit it to version control.
+        The format is identical to the global config above.
+    </p>
+
+    <h2 id="vscode">VS Code (GitHub Copilot)</h2>
+    <p>
+        Open <strong>User Settings (JSON)</strong> via <kbd>Cmd/Ctrl + Shift + P</kbd> → <em>Preferences: Open User Settings (JSON)</em> and add:
+    </p>
+    <pre class="language-js line-numbers">
+<code>
+{
+  "github.copilot.chat.mcpServers": {
+    "bladewindui": {
+      "type": "http",
+      "url": "https://bladewindui.com/mcp/server"
+    }
+  }
+}
+</code>
+    </pre>
+
+    <h2 id="tools">Available Tools</h2>
+    <p>Once connected, the AI can call three tools against the BladewindUI MCP server:</p>
+
+    <x-bladewind::table striped="true" has_shadow="false">
+        <x-slot name="header">
+            <th>Tool</th>
+            <th>Description</th>
+            <th>Input</th>
+        </x-slot>
+        <tr>
+            <td nowrap="nowrap"><code class="inline">list_components</code></td>
+            <td>Returns every component with its Blade tag and resource URI.</td>
+            <td>none</td>
+        </tr>
+        <tr>
+            <td nowrap="nowrap"><code class="inline">get_component_docs</code></td>
+            <td>Returns the full documentation for a single component.</td>
+            <td><code class="inline">name</code> — component slug, e.g. <code class="inline">button</code></td>
+        </tr>
+        <tr>
+            <td nowrap="nowrap"><code class="inline">search_components</code></td>
+            <td>Searches all component docs for a keyword and returns matching excerpts.</td>
+            <td><code class="inline">query</code> — keyword or phrase</td>
+        </tr>
+    </x-bladewind::table>
+
+    <h2 id="example-prompts">Example Prompts</h2>
+    <p>Once your editor is connected, try prompts like these in the AI chat:</p>
+    <ul class="list-disc pl-6 space-y-2">
+        <li><em>"List all BladewindUI components."</em></li>
+        <li><em>"How do I use the BladewindUI table component with pagination and sorting?"</em></li>
+        <li><em>"What attributes does the filepicker accept?"</em></li>
+        <li><em>"Show me a BladewindUI modal that confirms a destructive action."</em></li>
+        <li><em>"Search BladewindUI docs for anything related to dark mode."</em></li>
+        <li><em>"Generate a BladewindUI dashboard card with a statistic and an icon."</em></li>
+    </ul>
+
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+
+    <x-slot:side_nav>
+        <div class="flex items-center"><div class="dot"></div><a href="#what-is-available">What is available</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#claude-desktop">Claude Desktop</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#cursor">Cursor</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#vscode">VS Code</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#tools">Available tools</a></div>
+        <div class="flex items-center"><div class="dot"></div><a href="#example-prompts">Example prompts</a></div>
+    </x-slot:side_nav>
+
+    <x-slot name="scripts">
+        <script>
+            selectNavigationItem('.mcp-server');
+        </script>
+    </x-slot>
+</x-app>

--- a/resources/views/docs/nav.blade.php
+++ b/resources/views/docs/nav.blade.php
@@ -4,8 +4,7 @@
     <div class="flex items-center customization"><div class="dot"></div><a href="/customize">Customization</a></div>
     <div class="flex items-center colours"><div class="dot"></div><a href="/customize/colours">Colours</a></div>
     <div class="flex items-center darkmode"><div class="dot"></div><a href="/customize/darkmode">Dark Mode</a></div>
-    <div class="flex items-center upgrade"><div class="dot"></div><a href="https://github.com/mkocansey/bladewind/releases/tag/v3.0.0" target="_blank">v3.0 Release Notes</a></div>
-    <div class="flex items-center mcp-server"><div class="dot"></div><a href="/mcp">MCP Server</a></div>
+    <div class="flex items-center mcp-server"><div class="dot"></div><a href="/mcp">MCP Server <x-bladewind::icon name="bolt" type="solid" class="text-pink-600 !size-3 ml-1" /></a></div>
 </div>
 
 <h5 class="nav-heading">Components</h5>

--- a/resources/views/docs/nav.blade.php
+++ b/resources/views/docs/nav.blade.php
@@ -5,6 +5,7 @@
     <div class="flex items-center colours"><div class="dot"></div><a href="/customize/colours">Colours</a></div>
     <div class="flex items-center darkmode"><div class="dot"></div><a href="/customize/darkmode">Dark Mode</a></div>
     <div class="flex items-center upgrade"><div class="dot"></div><a href="https://github.com/mkocansey/bladewind/releases/tag/v3.0.0" target="_blank">v3.0 Release Notes</a></div>
+    <div class="flex items-center mcp-server"><div class="dot"></div><a href="/mcp">MCP Server</a></div>
 </div>
 
 <h5 class="nav-heading">Components</h5>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\FileUploadController;
+use App\Http\Controllers\McpController;
 use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'docs/index')->name('home');
@@ -25,6 +26,10 @@ Route::view('component/empty-state', 'docs/emptystate');
 Route::view('component/filepicker', 'docs/filepicker');
 Route::view('component/horizontal-line-graph', 'docs/horizontal-line-graph');
 Route::view('contribute', 'docs/contribute');
+Route::view('mcp', 'docs/mcp');
+
+// MCP (Model Context Protocol) server — consumed by AI tools, not browsers
+Route::post('mcp/server', [McpController::class, 'handle']);
 Route::view('component/icon', 'docs/icon');
 Route::view('component/input', 'docs/input');
 Route::view('component/list-view', 'docs/list');

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,6 @@ Route::view('component/horizontal-line-graph', 'docs/horizontal-line-graph');
 Route::view('contribute', 'docs/contribute');
 Route::view('mcp', 'docs/mcp');
 
-// MCP (Model Context Protocol) server — consumed by AI tools, not browsers
 Route::post('mcp/server', [McpController::class, 'handle']);
 Route::view('component/icon', 'docs/icon');
 Route::view('component/input', 'docs/input');
@@ -36,6 +35,7 @@ Route::view('component/list-view', 'docs/list');
 Route::view('component/modal', 'docs/modal');
 Route::view('component/notification', 'docs/notification');
 Route::view('component/number', 'docs/number');
+Route::view('component/popover', 'docs/popover');
 Route::view('component/process-indicator', 'docs/process-indicator');
 Route::view('component/progress-bar', 'docs/progress-bar');
 Route::view('component/progress-circle', 'docs/progress-circle');


### PR DESCRIPTION
This pull request introduces major improvements to the BladewindUI documentation system by adding machine-readable MCP (Model Context Protocol) documentation for all components, automating documentation generation with a new script, updating dependencies, and making configuration changes to support AI tool integration. The most significant changes are grouped below.

**MCP Documentation System:**

* Added a new `mcp/` directory containing clean, machine-readable Markdown documentation for each BladewindUI component, intended for MCP servers and AI assistants. Includes comprehensive docs for components like `accordion` and `alert`. [[1]](diffhunk://#diff-396480377a7c10a8675bade3d9b9ee8c1b7b1c96dbb91c4aec9caa369a8239c8R1-R171) [[2]](diffhunk://#diff-a310ab9ec0f4f5304f9c2b93eb5c1a3e16ee237cb7ce8c9ff20c148ca993d16fR1-R162)
* Updated the `README.md` with detailed instructions on the MCP documentation system, including how to generate new docs and requirements for the generator script.

**Automation and Tooling:**

* Introduced `generate-mcp.php`, a PHP script that uses the Anthropic API to convert Blade documentation files into MCP-compliant Markdown, supporting options for dry-run, index updates, and filename overrides.

**Dependency and Configuration Updates:**

* Updated `composer.json` to use the latest stable BladewindUI package (`^4.1`) and removed the local path repository, ensuring production-ready dependency management. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L5-R12) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L74-L77)
* Modified `bootstrap/app.php` to exclude the MCP server endpoint from CSRF validation, allowing secure external AI tool consumption.